### PR TITLE
Fix typo in qemu-img log path

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -215,7 +215,7 @@ func (b *Builder) newDriver(qemuBinary string) (Driver, error) {
 		return nil, err
 	}
 
-	log.Printf("Qemu path: %s, Qemu Image page: %s", qemuPath, qemuImgPath)
+	log.Printf("Qemu path: %s, Qemu Image path: %s", qemuPath, qemuImgPath)
 	driver := &QemuDriver{
 		QemuPath:    qemuPath,
 		QemuImgPath: qemuImgPath,


### PR DESCRIPTION
Hi,

I found an odd log message. Here is an improvement suggestion. What do you think of this ?

Regards,
Étienne BERSAC