### PR TITLE
Fix cd_content is ignored

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -65,8 +65,9 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			Label:       b.config.FloppyConfig.FloppyLabel,
 		},
 		&commonsteps.StepCreateCD{
-			Files: b.config.CDConfig.CDFiles,
-			Label: b.config.CDConfig.CDLabel,
+			Files:   b.config.CDConfig.CDFiles,
+			Content: b.config.CDConfig.CDContent,
+			Label:   b.config.CDConfig.CDLabel,
 		},
 		&stepCreateDisk{
 			AdditionalDiskSize: b.config.AdditionalDiskSize,

--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -23,6 +23,8 @@ type Builder struct {
 	runner multistep.Runner
 }
 
+var _ packersdk.Builder = &Builder{}
+
 func (b *Builder) ConfigSpec() hcldec.ObjectSpec { return b.config.FlatMapstructure().HCL2Spec() }
 
 func (b *Builder) Prepare(raws ...interface{}) ([]string, []string, error) {

--- a/builder/qemu/builder_test.go
+++ b/builder/qemu/builder_test.go
@@ -1,1 +1,0 @@
-package qemu

--- a/builder/qemu/builder_test.go
+++ b/builder/qemu/builder_test.go
@@ -1,15 +1,1 @@
 package qemu
-
-import (
-	"testing"
-
-	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
-)
-
-func TestBuilder_ImplementsBuilder(t *testing.T) {
-	var raw interface{}
-	raw = &Builder{}
-	if _, ok := raw.(packersdk.Builder); !ok {
-		t.Error("Builder must implement builder.")
-	}
-}

--- a/builder/qemu/config_test.go
+++ b/builder/qemu/config_test.go
@@ -693,3 +693,21 @@ func TestBuilderPrepare_LoadQemuImgArgs(t *testing.T) {
 	assert.Equal(t, []string{"-baz", "bang"},
 		c.QemuImgArgs.Create, "Create args not loaded properly")
 }
+
+func TestBuilderPrepare_cd_content(t *testing.T) {
+	var c Config
+	config := testConfig()
+
+	config["cd_content"] = map[string]string{
+		"file.txt": "foo",
+	}
+
+	_, err := c.Prepare(config)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	if len(c.CDContent) == 0 {
+		t.Fatal("cd_content empty")
+	}
+}


### PR DESCRIPTION
This implements support for cd_content
(https://www.packer.io/docs/builders/qemu#cd_content)
by adding an omitted struct member.

I don't really have a template to test this fix with qemu, but it builds and seems obvious by analogy to
hashicorp/packer-plugin-hyperv#33 and hashicorp/packer-plugin-vmware#30

