### PR TITLE
Load the platform firmware via pflash

### DIFF
--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -104,11 +104,6 @@ func (s *stepRun) getDefaultArgs(config *Config, state multistep.StateBag) map[s
 			config.MachineType, config.Accelerator)
 	}
 
-	// Firmware
-	if config.Firmware != "" {
-		defaultArgs["-bios"] = config.Firmware
-	}
-
 	// Configure "-netdev" arguments
 	defaultArgs["-netdev"] = fmt.Sprintf("bridge,id=user.0,br=%s", config.NetBridge)
 	if config.NetBridge == "" {
@@ -278,6 +273,10 @@ func (s *stepRun) getDeviceAndDriveArgs(config *Config, state multistep.StateBag
 		} else {
 			driveArgs = append(driveArgs, fmt.Sprintf("file=%s,if=%s,index=%d,id=cdrom%d,media=cdrom", cdPath, config.CDROMInterface, i, i))
 		}
+	}
+	// Firmware
+	if config.Firmware != "" {
+		driveArgs = append(driveArgs, fmt.Sprintf("file=%s,if=pflash,format=raw,readonly=on", config.Firmware))
 	}
 
 	return deviceArgs, driveArgs


### PR DESCRIPTION
Currently setting the firmware option to <file> results in the following
QEMU command line:

  qemu -bios <file> ...

This works fine for legacy BIOS firmwares (like SeaBIOS), but does not
work so well for UEFI. Quoting the edk2 documentation[1]:

   ...
   Use OVMF for QEMU firmware (3 options available)
   ...
   - Option 2: Use QEMU -bios parameter
    * Note that UEFI variables will be partially emulated, and non-volatile
      variables may lose their contents after a reboot
   ...

In practice this means that QEMU may not read UEFI variables from the
firmware file. In my case I have the specially crafted OVMF.fd with
pre-defined boot order that is ignored by QEMU if -bios option is used.

This patch changes the way the platform firmware is loaded:

  old: qemu -bios <file> ...
  new: qemu -drive file=<file>,if=pflash,format=raw,readonly=on ...

The firmware is loaded read-only because several VMs sharing the same
firmware file will quickly mess it up.

Tested with SeaBIOS and OVMF2, both work fine.

[1] https://github.com/tianocore/edk2/blob/master/OvmfPkg/README

**DELETE THIS TEMPLATE BEFORE SUBMITTING**

In order to have a good experience with our community, we recommend that you
read the contributing guidelines for making a PR, and understand the lifecycle
of a Packer Plugin PR:

https://github.com/hashicorp/packer-plugin-qemu/blob/main/.github/CONTRIBUTING.md#opening-an-pull-request

Describe the change you are making here!

Please include tests. We recommend looking at existing tests as an example. 

If your PR resolves any open issue(s), please indicate them like this so they will be closed when your PR is merged:

Closes #xxx
Closes #xxx

