### PR TITLE
fix use_backing_file with qemu 6.1

### DIFF
--- a/builder/qemu/step_create_disk.go
+++ b/builder/qemu/step_create_disk.go
@@ -76,7 +76,7 @@ func (s *stepCreateDisk) buildCreateCommand(path string, size string, i int, sta
 	if s.DiskImage && s.UseBackingFile && i == 0 {
 		// Use a backing file for the 'main' or 'default' disk
 		isoPath := state.Get("iso_path").(string)
-		command = append(command, "-b", isoPath)
+		command = append(command, "-b", isoPath, "-F", "qcow2")
 	}
 
 	// add user-provided convert args

--- a/builder/qemu/step_create_disk_test.go
+++ b/builder/qemu/step_create_disk_test.go
@@ -34,7 +34,7 @@ func Test_buildCreateCommand(t *testing.T) {
 				AdditionalDiskSize: []string{"1M", "2M"},
 			},
 			0,
-			[]string{"create", "-f", "qcow2", "-b", "source.qcow2", "target.qcow2", "1234M"},
+			[]string{"create", "-f", "qcow2", "-b", "source.qcow2", "-F", "qcow2", "target.qcow2", "1234M"},
 			"Basic, happy path, backing store, additional disks",
 		},
 		{
@@ -57,7 +57,7 @@ func Test_buildCreateCommand(t *testing.T) {
 				},
 			},
 			0,
-			[]string{"create", "-f", "qcow2", "-b", "source.qcow2", "-foo", "bar", "target.qcow2", "1234M"},
+			[]string{"create", "-f", "qcow2", "-b", "source.qcow2", "-F", "qcow2", "-foo", "bar", "target.qcow2", "1234M"},
 			"Basic, happy path, backing store set, extra args",
 		},
 		{
@@ -100,7 +100,7 @@ func Test_StepCreateCalled(t *testing.T) {
 				UseBackingFile: true,
 			},
 			[]string{
-				"create", "-f", "qcow2", "-b", "source.qcow2", "target", "1M",
+				"create", "-f", "qcow2", "-b", "source.qcow2", "-F", "qcow2", "target", "1M",
 			},
 			"Basic, happy path, backing store, no additional disks",
 		},
@@ -153,7 +153,7 @@ func Test_StepCreateCalled(t *testing.T) {
 				AdditionalDiskSize: []string{"3M", "8M"},
 			},
 			[]string{
-				"create", "-f", "qcow2", "-b", "source.qcow2", "target", "1M",
+				"create", "-f", "qcow2", "-b", "source.qcow2", "-F", "qcow2", "target", "1M",
 				"create", "-f", "qcow2", "target-1", "3M",
 				"create", "-f", "qcow2", "target-2", "8M",
 			},


### PR DESCRIPTION
Fixes #47.

Adds backing file format argument for qemu-img in create disk step, to fix `use_backing_file` functionality with qemu 6.1 or later. For earlier qemu versions the change is desirable as well (as I understand, it was long deprecated to use backing file without specifying format, and now in 6.1 the backing format argument is mandatory).

From searching for all usages of `UseBackingFile` flag, it should be the only change needed. `qcow2` backing format is hardcoded, because I believe it's the only one supported. But this is my very first attempt at contributing to Packer code, so I may be wrong.