### PR TITLE
Add sata as a supported disk interface

### DIFF
--- a/builder/qemu/config.go
+++ b/builder/qemu/config.go
@@ -34,6 +34,7 @@ var accels = map[string]struct{}{
 
 var diskInterface = map[string]bool{
 	"ide":         true,
+	"sata":        true,
 	"scsi":        true,
 	"virtio":      true,
 	"virtio-scsi": true,
@@ -115,9 +116,9 @@ type Config struct {
 	// Also see the QEMU documentation.
 	Firmware string `mapstructure:"firmware" required:"false"`
 	// The interface to use for the disk. Allowed values include any of `ide`,
-	// `scsi`, `virtio` or `virtio-scsi`^\*. Note also that any boot commands
-	// or kickstart type scripts must have proper adjustments for resulting
-	// device names. The Qemu builder uses `virtio` by default.
+	// `sata`, `scsi`, `virtio` or `virtio-scsi`^\*. Note also that any boot
+	// commands or kickstart type scripts must have proper adjustments for
+	// resulting device names. The Qemu builder uses `virtio` by default.
 	//
 	// ^\* Please be aware that use of the `scsi` disk interface has been
 	// disabled by Red Hat due to a bug described

--- a/docs-partials/builder/qemu/Config-not-required.mdx
+++ b/docs-partials/builder/qemu/Config-not-required.mdx
@@ -42,9 +42,9 @@
   Also see the QEMU documentation.
 
 - `disk_interface` (string) - The interface to use for the disk. Allowed values include any of `ide`,
-  `scsi`, `virtio` or `virtio-scsi`^\*. Note also that any boot commands
-  or kickstart type scripts must have proper adjustments for resulting
-  device names. The Qemu builder uses `virtio` by default.
+  `sata`, `scsi`, `virtio` or `virtio-scsi`^\*. Note also that any boot
+  commands or kickstart type scripts must have proper adjustments for
+  resulting device names. The Qemu builder uses `virtio` by default.
   
   ^\* Please be aware that use of the `scsi` disk interface has been
   disabled by Red Hat due to a bug described

--- a/example/README.md
+++ b/example/README.md
@@ -1,14 +1,10 @@
 ## The Example Folder
 
-This folder must contain a fully working example of the plugin usage. The example must define the `required_plugins`
-block. A pre-defined GitHub Action will run `packer init`, `packer validate`, and `packer build` to test your plugin 
-with the latest version available of Packer.
+This folder must contain a fully working example of the plugin usage. The example must define the `required_plugins` block. A pre-defined GitHub Action will run `packer init`, `packer validate`, and `packer build` to test your plugin with the latest version available of Packer.
 
-The folder can contain multiple HCL2 compatible files. The action will execute Packer at this folder level
-running `packer init -upgrade .` and `packer build .`.
+The folder can contain multiple HCL2 compatible files. The action will execute Packer at this folder level running `packer init -upgrade .` and `packer build .`.
 
-If the plugin requires authentication, the configuration should be provided via GitHub Secrets and set as environment
-variables in the [test-plugin-example.yml](/.github/workflows/test-plugin-example.yml) file. Example:
+If the plugin requires authentication, the configuration should be provided via GitHub Secrets and set as environment variables in the [test-plugin-example.yml](/.github/workflows/test-plugin-example.yml) file. Example:
 
 ```yml
   - name: Build


### PR DESCRIPTION
Hello,

This PR adds the `sata` disk interface to the list of supported disk interfaces of Qemu builder.  #18 

Here is the [log](https://gist.github.com/LordNoteworthy/7fecac62582c3a70a21293390e31d199) of packer build.

I am not entirely sure if I just need to include `sata` in the map and that's it or I would need to modify some other parts as well. Please guide me what else needs to be changed if needed.

Cheers.

