### PR TITLE
Add an option flag to allow using a pflash for firmware

### DIFF
--- a/builder/qemu/config.go
+++ b/builder/qemu/config.go
@@ -109,12 +109,18 @@ type Config struct {
 	// The number of cpus to use when building the VM.
 	//  The default is `1` CPU.
 	CpuCount int `mapstructure:"cpus" required:"false"`
-	// The firmware file to be used by QEMU, which is to be set by the -bios
-	// option of QEMU. Particularly, this option can be set to use EFI instead
-	// of BIOS, by using "OVMF.fd" from OpenFirmware.
-	// If unset, no -bios option is passed to QEMU, using the default of QEMU.
+	// The firmware file to be used by QEMU
+	// this option could be set to use EFI instead of BIOS,
+	// by using "OVMF.fd" from OpenFirmware, for example.
+	// If unset, QEMU will load its default firmware.
 	// Also see the QEMU documentation.
 	Firmware string `mapstructure:"firmware" required:"false"`
+	// If a firmware file option was provided, this option can be
+	// used to change how qemu will get it.
+	// If false (the default), then the firmware is provided through
+	// the -bios option, but if true, a pflash drive will be used
+	// instead.
+	PFlash bool `mapstructure:"use_pflash" required:"false"`
 	// The interface to use for the disk. Allowed values include any of `ide`,
 	// `sata`, `scsi`, `virtio` or `virtio-scsi`^\*. Note also that any boot
 	// commands or kickstart type scripts must have proper adjustments for

--- a/builder/qemu/config.hcl2spec.go
+++ b/builder/qemu/config.hcl2spec.go
@@ -102,6 +102,7 @@ type FlatConfig struct {
 	AdditionalDiskSize        []string          `mapstructure:"disk_additional_size" required:"false" cty:"disk_additional_size" hcl:"disk_additional_size"`
 	CpuCount                  *int              `mapstructure:"cpus" required:"false" cty:"cpus" hcl:"cpus"`
 	Firmware                  *string           `mapstructure:"firmware" required:"false" cty:"firmware" hcl:"firmware"`
+	PFlash                    *bool             `mapstructure:"use_pflash" required:"false" cty:"use_pflash" hcl:"use_pflash"`
 	DiskInterface             *string           `mapstructure:"disk_interface" required:"false" cty:"disk_interface" hcl:"disk_interface"`
 	DiskSize                  *string           `mapstructure:"disk_size" required:"false" cty:"disk_size" hcl:"disk_size"`
 	SkipResizeDisk            *bool             `mapstructure:"skip_resize_disk" required:"false" cty:"skip_resize_disk" hcl:"skip_resize_disk"`
@@ -239,6 +240,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"disk_additional_size":         &hcldec.AttrSpec{Name: "disk_additional_size", Type: cty.List(cty.String), Required: false},
 		"cpus":                         &hcldec.AttrSpec{Name: "cpus", Type: cty.Number, Required: false},
 		"firmware":                     &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
+		"use_pflash":                   &hcldec.AttrSpec{Name: "use_pflash", Type: cty.Bool, Required: false},
 		"disk_interface":               &hcldec.AttrSpec{Name: "disk_interface", Type: cty.String, Required: false},
 		"disk_size":                    &hcldec.AttrSpec{Name: "disk_size", Type: cty.String, Required: false},
 		"skip_resize_disk":             &hcldec.AttrSpec{Name: "skip_resize_disk", Type: cty.Bool, Required: false},

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -104,6 +104,11 @@ func (s *stepRun) getDefaultArgs(config *Config, state multistep.StateBag) map[s
 			config.MachineType, config.Accelerator)
 	}
 
+	// Firmware
+	if config.Firmware != "" && !config.PFlash {
+		defaultArgs["-bios"] = config.Firmware
+	}
+
 	// Configure "-netdev" arguments
 	defaultArgs["-netdev"] = fmt.Sprintf("bridge,id=user.0,br=%s", config.NetBridge)
 	if config.NetBridge == "" {
@@ -275,7 +280,7 @@ func (s *stepRun) getDeviceAndDriveArgs(config *Config, state multistep.StateBag
 		}
 	}
 	// Firmware
-	if config.Firmware != "" {
+	if config.Firmware != "" && config.PFlash {
 		driveArgs = append(driveArgs, fmt.Sprintf("file=%s,if=pflash,format=raw,readonly=on", config.Firmware))
 	}
 

--- a/docs-partials/builder/qemu/Config-not-required.mdx
+++ b/docs-partials/builder/qemu/Config-not-required.mdx
@@ -35,11 +35,17 @@
 - `cpus` (int) - The number of cpus to use when building the VM.
    The default is `1` CPU.
 
-- `firmware` (string) - The firmware file to be used by QEMU, which is to be set by the -bios
-  option of QEMU. Particularly, this option can be set to use EFI instead
-  of BIOS, by using "OVMF.fd" from OpenFirmware.
-  If unset, no -bios option is passed to QEMU, using the default of QEMU.
+- `firmware` (string) - The firmware file to be used by QEMU
+  this option could be set to use EFI instead of BIOS,
+  by using "OVMF.fd" from OpenFirmware, for example.
+  If unset, QEMU will load its default firmware.
   Also see the QEMU documentation.
+
+- `use_pflash` (bool) - If a firmware file option was provided, this option can be
+  used to change how qemu will get it.
+  If false (the default), then the firmware is provided through
+  the -bios option, but if true, a pflash drive will be used
+  instead.
 
 - `disk_interface` (string) - The interface to use for the disk. Allowed values include any of `ide`,
   `sata`, `scsi`, `virtio` or `virtio-scsi`^\*. Note also that any boot


### PR DESCRIPTION
Provide  an escape hatch so the solution implemented with #43 could be used without introducing regressions by default.

Closes: #66