### PR TITLE
Fixed bug where skip_nat_mapping would overwrite winrm_host to 127.0.0.1

### DIFF
--- a/builder/qemu/comm_config.go
+++ b/builder/qemu/comm_config.go
@@ -46,7 +46,7 @@ func (c *CommConfig) Prepare(ctx *interpolate.Context) (warnings []string, errs 
 		c.HostPortMax = c.SSHHostPortMax
 	}
 
-	if c.Comm.SSHHost == "" && c.SkipNatMapping {
+	if (c.Comm.SSHHost == "" || c.Comm.WinRMHost == "") && c.SkipNatMapping {
 		c.Comm.SSHHost = "127.0.0.1"
 		c.Comm.WinRMHost = "127.0.0.1"
 	}


### PR DESCRIPTION
In order to have a good experience with our community, we recommend that you
read the contributing guidelines for making a PR, and understand the lifecycle
of a Packer Plugin PR:

https://github.com/hashicorp/packer-plugin-qemu/blob/main/.github/CONTRIBUTING.md#opening-an-pull-request

This merge request fixes bug where skip_nat_mapping would overwrite winrm_host to 127.0.0.1. It was due to a weird condition only checking for SSHHost and then setting both SSHHost and WinRMHost.

Please include tests. We recommend looking at existing tests as an example. 
I am sorry I am not skilled enough to add tests, but I am quite sure this would be an easy task adding them.

