### PR TITLE
Add support of floppy_content

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -63,6 +63,7 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	steps = append(steps, new(stepPrepareOutputDir),
 		&commonsteps.StepCreateFloppy{
 			Files:       b.config.FloppyConfig.FloppyFiles,
+			Content:     b.config.FloppyConfig.FloppyContent,
 			Directories: b.config.FloppyConfig.FloppyDirectories,
 			Label:       b.config.FloppyConfig.FloppyLabel,
 		},


### PR DESCRIPTION
This PR includes the required changes to add the support of "floppy_content" to the qemu builder plugin.

The logic is already build in packer or the base plugin so it basically resumes to allowing the directive having a meaning for this builder.

This is especially useful if you have template files that you need to include in a floppy disk (e.g. an autounattend file for Windows).


