### PR TITLE
Fix issues reported by Go checks

### DIFF
--- a/.golangci.yml
+++ b/.golangci.yml
@@ -27,7 +27,6 @@ issues:
 linters:
   disable-all: true
   enable:
-    - deadcode
     - errcheck
     - goimports
     - gosimple
@@ -36,7 +35,6 @@ linters:
     - staticcheck
     - unconvert
     - unused
-    - varcheck
   fast: true
 
 # options for analysis running

--- a/builder/qemu/step_configure_qmp.go
+++ b/builder/qemu/step_configure_qmp.go
@@ -12,13 +12,7 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
-// This step configures the VM to enable the QMP listener.
-//
-// Uses:
-//   config *config
-//   ui     packersdk.Ui
-//
-// Produces:
+// stepConfigureQMP configures the VM to enable the QMP listener.
 type stepConfigureQMP struct {
 	monitor       *qmp.SocketMonitor
 	QMPSocketPath string

--- a/builder/qemu/step_configure_vnc.go
+++ b/builder/qemu/step_configure_vnc.go
@@ -11,14 +11,7 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
-// This step configures the VM to enable the VNC server.
-//
-// Uses:
-//   config *config
-//   ui     packersdk.Ui
-//
-// Produces:
-//   vnc_port int - The port that VNC is configured to listen on.
+// stepConfigureVNC configures the VM to enable the VNC server.
 type stepConfigureVNC struct {
 	l *net.Listener
 }

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -112,7 +112,7 @@ func (s *stepRun) getDefaultArgs(config *Config, state multistep.StateBag) map[s
 	// Configure "-netdev" arguments
 	defaultArgs["-netdev"] = fmt.Sprintf("bridge,id=user.0,br=%s", config.NetBridge)
 	if config.NetBridge == "" {
-		defaultArgs["-netdev"] = fmt.Sprintf("user,id=user.0")
+		defaultArgs["-netdev"] = "user,id=user.0"
 		if config.CommConfig.Comm.Type != "none" {
 			commHostPort := state.Get("commHostPort").(int)
 			defaultArgs["-netdev"] = fmt.Sprintf("user,id=user.0,hostfwd=tcp::%v-:%d", commHostPort, config.CommConfig.Comm.Port())

--- a/builder/qemu/step_shutdown.go
+++ b/builder/qemu/step_shutdown.go
@@ -12,17 +12,8 @@ import (
 	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
 )
 
-// This step shuts down the machine. It first attempts to do so gracefully,
+// stepShutdown shuts down the machine. It first attempts to do so gracefully,
 // but ultimately forcefully shuts it down if that fails.
-//
-// Uses:
-//   communicator packersdk.Communicator
-//   config *config
-//   driver Driver
-//   ui     packersdk.Ui
-//
-// Produces:
-//   <nothing>
 type stepShutdown struct {
 	ShutdownCommand string
 	ShutdownTimeout time.Duration

--- a/builder/qemu/step_type_boot_command.go
+++ b/builder/qemu/step_type_boot_command.go
@@ -22,16 +22,7 @@ type bootCommandTemplateData struct {
 	Name     string
 }
 
-// This step "types" the boot command into the VM over VNC.
-//
-// Uses:
-//   config *config
-//   http_port int
-//   ui     packersdk.Ui
-//   vnc_port int
-//
-// Produces:
-//   <nothing>
+// stepTypeBootCommand "types" the boot command into the VM over VNC.
 type stepTypeBootCommand struct{}
 
 func (s *stepTypeBootCommand) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {


### PR DESCRIPTION
- Fix spacing in comments to address goimports errors
- Remove unnecessary use of fmt.Sprintf
- Remove deprecated linters
