### PR TITLE
builder: call Comm.Prepare before resetting host

### DIFF
--- a/builder/qemu/comm_config.go
+++ b/builder/qemu/comm_config.go
@@ -3,6 +3,7 @@ package qemu
 
 import (
 	"errors"
+	"log"
 
 	"github.com/hashicorp/packer-plugin-sdk/communicator"
 	"github.com/hashicorp/packer-plugin-sdk/template/interpolate"
@@ -46,11 +47,6 @@ func (c *CommConfig) Prepare(ctx *interpolate.Context) (warnings []string, errs 
 		c.HostPortMax = c.SSHHostPortMax
 	}
 
-	if c.Comm.Host() == "" && c.SkipNatMapping {
-		c.Comm.SSHHost = "127.0.0.1"
-		c.Comm.WinRMHost = "127.0.0.1"
-	}
-
 	if c.HostPortMin == 0 {
 		c.HostPortMin = 2222
 	}
@@ -60,6 +56,13 @@ func (c *CommConfig) Prepare(ctx *interpolate.Context) (warnings []string, errs 
 	}
 
 	errs = c.Comm.Prepare(ctx)
+
+	if c.Comm.Host() == "" && c.SkipNatMapping {
+		log.Printf("Resetting ssh host to 127.0.0.1")
+		c.Comm.SSHHost = "127.0.0.1"
+		c.Comm.WinRMHost = "127.0.0.1"
+	}
+
 	if c.HostPortMin > c.HostPortMax {
 		errs = append(errs,
 			errors.New("host_port_min must be less than host_port_max"))

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -112,7 +112,7 @@ func (s *stepRun) getDefaultArgs(config *Config, state multistep.StateBag) map[s
 	// Configure "-netdev" arguments
 	defaultArgs["-netdev"] = fmt.Sprintf("bridge,id=user.0,br=%s", config.NetBridge)
 	if config.NetBridge == "" {
-		defaultArgs["-netdev"] = fmt.Sprintf("user,id=user.0")
+		defaultArgs["-netdev"] = "user,id=user.0"
 		if config.CommConfig.Comm.Type != "none" {
 			commHostPort := state.Get("commHostPort").(int)
 			defaultArgs["-netdev"] = fmt.Sprintf("user,id=user.0,hostfwd=tcp::%v-:%d", commHostPort, config.CommConfig.Comm.Port())


### PR DESCRIPTION
A regression was introduced in the plugin in commit f65be3cb, where the logic for detecting a missing host, and falling back to localhost used to work with SSH only, and was generalised through the `Host()' method to work with WinRM too.

This logic however was flawed, as it required an explicit Type for the communicator to work. This is the case for winrm, but ssh being the default didn't need to, leading to the case where we resetted the host to 127.0.0.1.

To prevent this, we ensure the Type is properly set, which is done in the `c.Comm.Prepare` function, from the packer SDK. This in turn makes `Host()` report the right host for implicit ssh connections, and not an empty one as previously would happen.

Closes: https://github.com/hashicorp/packer/issues/11961

