### PR TITLE
Cut release 1.0.6

### DIFF
--- a/version/version.go
+++ b/version/version.go
@@ -4,7 +4,7 @@ import "github.com/hashicorp/packer-plugin-sdk/version"
 
 var (
 	// Version is the main version number that is being run at the moment.
-	Version = "1.0.5"
+	Version = "1.0.6"
 
 	// VersionPrerelease is A pre-release marker for the Version. If this is ""
 	// (empty string) then it means that it is a final release. Otherwise, this


### PR DESCRIPTION
Getting ready for releasing v1.0.6 of the qemu plugin, most notably with the ssh_host fix when no communicator is explicitely defined in a template.
