### PR TITLE
builder: add more options for CPU topology

### DIFF
--- a/builder/qemu/config.hcl2spec.go
+++ b/builder/qemu/config.hcl2spec.go
@@ -97,10 +97,13 @@ type FlatConfig struct {
 	CDFiles                   []string          `mapstructure:"cd_files" cty:"cd_files" hcl:"cd_files"`
 	CDContent                 map[string]string `mapstructure:"cd_content" cty:"cd_content" hcl:"cd_content"`
 	CDLabel                   *string           `mapstructure:"cd_label" cty:"cd_label" hcl:"cd_label"`
+	CpuCount                  *int              `mapstructure:"cpus" required:"false" cty:"cpus" hcl:"cpus"`
+	SocketCount               *int              `mapstructure:"sockets" required:"false" cty:"sockets" hcl:"sockets"`
+	CoreCount                 *int              `mapstructure:"cores" required:"false" cty:"cores" hcl:"cores"`
+	ThreadCount               *int              `mapstructure:"threads" required:"false" cty:"threads" hcl:"threads"`
 	ISOSkipCache              *bool             `mapstructure:"iso_skip_cache" required:"false" cty:"iso_skip_cache" hcl:"iso_skip_cache"`
 	Accelerator               *string           `mapstructure:"accelerator" required:"false" cty:"accelerator" hcl:"accelerator"`
 	AdditionalDiskSize        []string          `mapstructure:"disk_additional_size" required:"false" cty:"disk_additional_size" hcl:"disk_additional_size"`
-	CpuCount                  *int              `mapstructure:"cpus" required:"false" cty:"cpus" hcl:"cpus"`
 	Firmware                  *string           `mapstructure:"firmware" required:"false" cty:"firmware" hcl:"firmware"`
 	PFlash                    *bool             `mapstructure:"use_pflash" required:"false" cty:"use_pflash" hcl:"use_pflash"`
 	DiskInterface             *string           `mapstructure:"disk_interface" required:"false" cty:"disk_interface" hcl:"disk_interface"`
@@ -235,10 +238,13 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"cd_files":                     &hcldec.AttrSpec{Name: "cd_files", Type: cty.List(cty.String), Required: false},
 		"cd_content":                   &hcldec.AttrSpec{Name: "cd_content", Type: cty.Map(cty.String), Required: false},
 		"cd_label":                     &hcldec.AttrSpec{Name: "cd_label", Type: cty.String, Required: false},
+		"cpus":                         &hcldec.AttrSpec{Name: "cpus", Type: cty.Number, Required: false},
+		"sockets":                      &hcldec.AttrSpec{Name: "sockets", Type: cty.Number, Required: false},
+		"cores":                        &hcldec.AttrSpec{Name: "cores", Type: cty.Number, Required: false},
+		"threads":                      &hcldec.AttrSpec{Name: "threads", Type: cty.Number, Required: false},
 		"iso_skip_cache":               &hcldec.AttrSpec{Name: "iso_skip_cache", Type: cty.Bool, Required: false},
 		"accelerator":                  &hcldec.AttrSpec{Name: "accelerator", Type: cty.String, Required: false},
 		"disk_additional_size":         &hcldec.AttrSpec{Name: "disk_additional_size", Type: cty.List(cty.String), Required: false},
-		"cpus":                         &hcldec.AttrSpec{Name: "cpus", Type: cty.Number, Required: false},
 		"firmware":                     &hcldec.AttrSpec{Name: "firmware", Type: cty.String, Required: false},
 		"use_pflash":                   &hcldec.AttrSpec{Name: "use_pflash", Type: cty.Bool, Required: false},
 		"disk_interface":               &hcldec.AttrSpec{Name: "disk_interface", Type: cty.String, Required: false},

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -145,9 +145,7 @@ func (s *stepRun) getDefaultArgs(config *Config, state multistep.StateBag) map[s
 	defaultArgs["-m"] = fmt.Sprintf("%dM", config.MemorySize)
 
 	// Configure "-smp" processor hardware arguments
-	if config.CpuCount > 1 {
-		defaultArgs["-smp"] = fmt.Sprintf("cpus=%d,sockets=%d", config.CpuCount, config.CpuCount)
-	}
+	defaultArgs["-smp"] = config.QemuSMPConfig.getDefaultCmdLine()
 
 	// Configure "-fda" floppy disk attachment
 	if floppyPathRaw, ok := state.GetOk("floppy_path"); ok {

--- a/docs-partials/builder/qemu/Config-not-required.mdx
+++ b/docs-partials/builder/qemu/Config-not-required.mdx
@@ -32,9 +32,6 @@
   Each additional disk uses the same disk parameters as the default disk.
   Unset by default.
 
-- `cpus` (int) - The number of cpus to use when building the VM.
-   The default is `1` CPU.
-
 - `firmware` (string) - The firmware file to be used by QEMU
   this option could be set to use EFI instead of BIOS,
   by using "OVMF.fd" from OpenFirmware, for example.

--- a/docs-partials/builder/qemu/QemuSMPConfig-not-required.mdx
+++ b/docs-partials/builder/qemu/QemuSMPConfig-not-required.mdx
@@ -1,0 +1,26 @@
+<!-- Code generated from the comments of the QemuSMPConfig struct in builder/qemu/config.go; DO NOT EDIT MANUALLY -->
+
+- `cpus` (int) - The number of virtual cpus to use when building the VM.
+  
+  If undefined, the value will either be `1`, or the product of
+  `sockets * cpus * threads`
+  
+  If this is defined in conjunction with any topology specifier (sockets,
+  cores and/or threads), the smallest of the two will be used.
+  
+  If the cpu count is the only thing specified, qemu's default behaviour
+  regarding topology will be applied.
+  The behaviour depends on the version of qemu; before version 6.2, sockets
+  were preferred to cores, from version 6.2 onwards, cores are preferred.
+
+- `sockets` (int) - The number of sockets to use when building the VM.
+   The default is `1` socket.
+   The socket count must not be higher than the CPU count.
+
+- `cores` (int) - The number of cores per CPU to use when building the VM.
+   The default is `1` core per CPU.
+
+- `threads` (int) - The number of threads per core to use when building the VM.
+   The default is `1` thread per core.
+
+<!-- End of code generated from the comments of the QemuSMPConfig struct in builder/qemu/config.go; -->

--- a/docs-partials/builder/qemu/QemuSMPConfig.mdx
+++ b/docs-partials/builder/qemu/QemuSMPConfig.mdx
@@ -1,0 +1,8 @@
+<!-- Code generated from the comments of the QemuSMPConfig struct in builder/qemu/config.go; DO NOT EDIT MANUALLY -->
+
+QemuSMPConfig sets the smp configuration option for the Qemu command-line
+
+The smp option sets the number of vCPUs to expose to the VM, the final
+number of available vCPUs is sockets*cores*threads.
+
+<!-- End of code generated from the comments of the QemuSMPConfig struct in builder/qemu/config.go; -->


### PR DESCRIPTION
In order to mirror more closely the options offered by qemu when it comes to expressing the topology of the SMP architecture we are building an image upon, we add more options to the configuration supported by the plugin.

In addition to cpus, we now support sockets, cores and threads. These may be used in conjunction with the cpus, or left to be computed by the plugin directly.

By default, any configuration which only defined cpus will work potentially differently from before, since this is supported by qemu, but the behaviour changes depending on the version.

Closes #55 

