### PR TITLE
qemu: add vTPM support on UNIX

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -61,6 +61,11 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 	}
 
 	steps = append(steps, new(stepPrepareOutputDir),
+		&stepCreatevTPM{
+			enableVTPM: b.config.VTPM,
+			vtpmType:   b.config.TPMType,
+			isTPM1:     b.config.VTPMUseTPM1,
+		},
 		&commonsteps.StepCreateFloppy{
 			Files:       b.config.FloppyConfig.FloppyFiles,
 			Content:     b.config.FloppyConfig.FloppyContent,

--- a/builder/qemu/config.hcl2spec.go
+++ b/builder/qemu/config.hcl2spec.go
@@ -136,6 +136,9 @@ type FlatConfig struct {
 	VNCPortMax                *int              `mapstructure:"vnc_port_max" cty:"vnc_port_max" hcl:"vnc_port_max"`
 	VMName                    *string           `mapstructure:"vm_name" required:"false" cty:"vm_name" hcl:"vm_name"`
 	CDROMInterface            *string           `mapstructure:"cdrom_interface" required:"false" cty:"cdrom_interface" hcl:"cdrom_interface"`
+	VTPM                      *bool             `mapstructure:"vtpm" required:"false" cty:"vtpm" hcl:"vtpm"`
+	VTPMUseTPM1               *bool             `mapstructure:"use_tpm1" required:"false" cty:"use_tpm1" hcl:"use_tpm1"`
+	TPMType                   *string           `mapstructure:"tpm_device_type" required:"false" cty:"tpm_device_type" hcl:"tpm_device_type"`
 	RunOnce                   *bool             `mapstructure:"run_once" cty:"run_once" hcl:"run_once"`
 }
 
@@ -277,6 +280,9 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vnc_port_max":                 &hcldec.AttrSpec{Name: "vnc_port_max", Type: cty.Number, Required: false},
 		"vm_name":                      &hcldec.AttrSpec{Name: "vm_name", Type: cty.String, Required: false},
 		"cdrom_interface":              &hcldec.AttrSpec{Name: "cdrom_interface", Type: cty.String, Required: false},
+		"vtpm":                         &hcldec.AttrSpec{Name: "vtpm", Type: cty.Bool, Required: false},
+		"use_tpm1":                     &hcldec.AttrSpec{Name: "use_tpm1", Type: cty.Bool, Required: false},
+		"tpm_device_type":              &hcldec.AttrSpec{Name: "tpm_device_type", Type: cty.String, Required: false},
 		"run_once":                     &hcldec.AttrSpec{Name: "run_once", Type: cty.Bool, Required: false},
 	}
 	return s

--- a/builder/qemu/step_create_vtpm.go
+++ b/builder/qemu/step_create_vtpm.go
@@ -1,0 +1,109 @@
+package qemu
+
+import (
+	"context"
+	"fmt"
+	"log"
+	"os"
+	"os/exec"
+	"runtime"
+
+	"github.com/hashicorp/packer-plugin-sdk/multistep"
+	packersdk "github.com/hashicorp/packer-plugin-sdk/packer"
+)
+
+type stepCreatevTPM struct {
+	enableVTPM bool
+	vtpmType   string
+	isTPM1     bool
+}
+
+const (
+	qemuVTPM        string = "qemu_vtpm"
+	swtpmProcess    string = "qemu_swtpm_process"
+	swtpmTmpDir     string = "qemu_swtpm_dir"
+	swtpmSocketPath string = "qemu_swtpm_socket_path"
+)
+
+func (s *stepCreatevTPM) Run(ctx context.Context, state multistep.StateBag) multistep.StepAction {
+	if !s.enableVTPM {
+		return multistep.ActionContinue
+	}
+
+	ui := state.Get("ui").(packersdk.Ui)
+
+	if runtime.GOOS == "windows" {
+		ui.Error("vTPM is only supported on UNIX OSes for now")
+		return multistep.ActionHalt
+	}
+
+	swtpmPath, err := exec.LookPath("swtpm")
+	if err != nil {
+		ui.Error(fmt.Sprintf(
+			"failed to locate swtpm (%s), this is required for vTPM support",
+			err))
+		return multistep.ActionHalt
+	}
+
+	vtpmDeviceDir, err := os.MkdirTemp("", "")
+	if err != nil {
+		ui.Error(fmt.Sprintf("failed to create vtpm state directory: %s", err))
+		return multistep.ActionHalt
+	}
+
+	state.Put(swtpmTmpDir, vtpmDeviceDir)
+
+	sockPath := fmt.Sprintf("%s/vtpm.sock", vtpmDeviceDir)
+
+	state.Put(swtpmSocketPath, sockPath)
+	if err != nil {
+		ui.Error(fmt.Sprintf(
+			"failed to create swtpm communication: %s",
+			err))
+		return multistep.ActionHalt
+	}
+
+	args := []string{
+		"socket",
+		"--tpmstate", fmt.Sprintf("dir=%s", vtpmDeviceDir),
+		"--ctrl", fmt.Sprintf("type=unixio,path=%s", sockPath),
+	}
+
+	if !s.isTPM1 {
+		args = append(args, "--tpm2")
+	}
+
+	swtpm := exec.Command(swtpmPath, args...)
+	swtpm.Stdout = os.Stdout
+	swtpm.Stderr = os.Stderr
+
+	state.Put(qemuVTPM, true)
+
+	log.Printf("Executing swtpm: %+v", args)
+	err = swtpm.Start()
+	if err != nil {
+		ui.Error(fmt.Sprintf(
+			"failed to start swtpm: %s", err))
+		return multistep.ActionHalt
+	}
+
+	state.Put(swtpmProcess, swtpm.Process)
+
+	return multistep.ActionContinue
+}
+
+func (s *stepCreatevTPM) Cleanup(state multistep.StateBag) {
+	process, ok := state.GetOk(swtpmProcess)
+	if !ok {
+		return
+	}
+
+	log.Printf("killing swtpm with PID %d", process.(*os.Process).Pid)
+	err := process.(*os.Process).Kill()
+	if err != nil {
+		log.Printf("failed to kill swtpm: %s", err)
+	}
+
+	tmpDir := state.Get(swtpmTmpDir).(string)
+	os.RemoveAll(tmpDir)
+}

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -173,6 +173,12 @@ func (s *stepRun) getDefaultArgs(config *Config, state multistep.StateBag) map[s
 		}
 	}
 
+	if config.VTPM {
+		vtpmSockPath := state.Get(swtpmSocketPath)
+		defaultArgs["-chardev"] = fmt.Sprintf("socket,id=vtpm,path=%s", vtpmSockPath)
+		defaultArgs["-tpmdev"] = "emulator,id=tpm0,chardev=vtpm"
+	}
+
 	deviceArgs, driveArgs := s.getDeviceAndDriveArgs(config, state)
 	defaultArgs["-device"] = deviceArgs
 	defaultArgs["-drive"] = driveArgs
@@ -280,6 +286,11 @@ func (s *stepRun) getDeviceAndDriveArgs(config *Config, state multistep.StateBag
 	// Firmware
 	if config.Firmware != "" && config.PFlash {
 		driveArgs = append(driveArgs, fmt.Sprintf("file=%s,if=pflash,format=raw,readonly=on", config.Firmware))
+	}
+
+	// TPM
+	if config.VTPM {
+		deviceArgs = append(deviceArgs, fmt.Sprintf("%s,tpmdev=tpm0", config.TPMType))
 	}
 
 	return deviceArgs, driveArgs

--- a/docs-partials/builder/qemu/Config-not-required.mdx
+++ b/docs-partials/builder/qemu/Config-not-required.mdx
@@ -332,4 +332,22 @@
   `virtio-scsi`. The Qemu builder uses `virtio` by default.
   Some ARM64 images require `virtio-scsi`.
 
+- `vtpm` (bool) - Use a virtual (emulated) TPM device to expose to the VM.
+
+- `use_tpm1` (bool) - Use version 1.2 of the TPM specification for the emulated TPM.
+  
+  By default, we use version 2.0 of the TPM specs for the emulated TPM,
+  if you want to force version 1.2, set this option to true.
+
+- `tpm_device_type` (string) - The TPM device type to inject in the qemu command-line
+  
+  This is required to be specified for some platforms, as the device has to
+  behave differently depending on the architecture.
+  
+  As per the docs:
+  
+   * x86: tpm-tis (default)
+   * ARM: tpm-tis-device
+   * PPC (p-series): tpm-spapr
+
 <!-- End of code generated from the comments of the Config struct in builder/qemu/config.go; -->


### PR DESCRIPTION
TPM is a co-processor specialised in handling security-related computations like encryption for example.

It is standard in many x86 installations nowadays, and is also available as an external module for some other architectures.

Qemu supports TPM in both passthrough and emulated mode, and SeaBIOS is able to discover it and expose it to the guest machine.

This commit adds a basic support for vTPM through swtpm, for now on UNIX OSes only, as it communicates over a UNIX socket.

Windows support will likely come later, as TCP is a bit more finicky, as will TPM passthrough in a later version of the plugin.

Closes #83 

