### PR TITLE
goreleaser: add ppc64le target on linux

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -40,6 +40,7 @@ builds:
       - '386'
       - arm
       - arm64
+      - ppc64le
     ignore:
       - goos: linux
         goarch: amd64


### PR DESCRIPTION
As requested by OSU, we add the ppc64le build to the upcoming releases of the plugin.