### PR TITLE
qemu: add support for vga card emulation

### DIFF
--- a/builder/qemu/config.go
+++ b/builder/qemu/config.go
@@ -471,6 +471,10 @@ type Config struct {
 	// to qemu, allowing it to choose the default. This may be needed when running
 	// under macOS, and getting errors about sdl not being available.
 	UseDefaultDisplay bool `mapstructure:"use_default_display" required:"false"`
+	// The type of VGA card to emulate. If undefined, this will not be included
+	// in the command-line, and the default qemu value for the emulated machine
+	// will be picked.
+	VGA string `mapstructure:"vga" required:"false"`
 	// What QEMU -display option to use. Defaults to gtk, use none to not pass the
 	// -display option allowing QEMU to choose the default. This may be needed when
 	// running under macOS, and getting errors about sdl not being available.

--- a/builder/qemu/config.hcl2spec.go
+++ b/builder/qemu/config.hcl2spec.go
@@ -129,6 +129,7 @@ type FlatConfig struct {
 	QMPEnable                 *bool             `mapstructure:"qmp_enable" required:"false" cty:"qmp_enable" hcl:"qmp_enable"`
 	QMPSocketPath             *string           `mapstructure:"qmp_socket_path" required:"false" cty:"qmp_socket_path" hcl:"qmp_socket_path"`
 	UseDefaultDisplay         *bool             `mapstructure:"use_default_display" required:"false" cty:"use_default_display" hcl:"use_default_display"`
+	VGA                       *string           `mapstructure:"vga" required:"false" cty:"vga" hcl:"vga"`
 	Display                   *string           `mapstructure:"display" required:"false" cty:"display" hcl:"display"`
 	VNCBindAddress            *string           `mapstructure:"vnc_bind_address" required:"false" cty:"vnc_bind_address" hcl:"vnc_bind_address"`
 	VNCUsePassword            *bool             `mapstructure:"vnc_use_password" required:"false" cty:"vnc_use_password" hcl:"vnc_use_password"`
@@ -273,6 +274,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"qmp_enable":                   &hcldec.AttrSpec{Name: "qmp_enable", Type: cty.Bool, Required: false},
 		"qmp_socket_path":              &hcldec.AttrSpec{Name: "qmp_socket_path", Type: cty.String, Required: false},
 		"use_default_display":          &hcldec.AttrSpec{Name: "use_default_display", Type: cty.Bool, Required: false},
+		"vga":                          &hcldec.AttrSpec{Name: "vga", Type: cty.String, Required: false},
 		"display":                      &hcldec.AttrSpec{Name: "display", Type: cty.String, Required: false},
 		"vnc_bind_address":             &hcldec.AttrSpec{Name: "vnc_bind_address", Type: cty.String, Required: false},
 		"vnc_use_password":             &hcldec.AttrSpec{Name: "vnc_use_password", Type: cty.Bool, Required: false},

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -179,6 +179,10 @@ func (s *stepRun) getDefaultArgs(config *Config, state multistep.StateBag) map[s
 		defaultArgs["-tpmdev"] = "emulator,id=tpm0,chardev=vtpm"
 	}
 
+	if config.VGA != "" {
+		defaultArgs["-vga"] = config.VGA
+	}
+
 	deviceArgs, driveArgs := s.getDeviceAndDriveArgs(config, state)
 	defaultArgs["-device"] = deviceArgs
 	defaultArgs["-drive"] = driveArgs

--- a/builder/qemu/step_run_test.go
+++ b/builder/qemu/step_run_test.go
@@ -711,6 +711,18 @@ func Test_Defaults(t *testing.T) {
 			[]string{"-display", "gtk"},
 			"Display option should default to gtk",
 		},
+		{
+			&Config{
+				VGA: "virtio",
+			},
+			map[string]interface{}{},
+			&stepRun{
+				DiskImage: true,
+				ui:        packersdk.TestUi(t),
+			},
+			[]string{"-vga", "virtio"},
+			"VGA should be set to virtio",
+		},
 	}
 
 	for _, tc := range testcases {

--- a/docs-partials/builder/qemu/Config-not-required.mdx
+++ b/docs-partials/builder/qemu/Config-not-required.mdx
@@ -300,6 +300,10 @@
   to qemu, allowing it to choose the default. This may be needed when running
   under macOS, and getting errors about sdl not being available.
 
+- `vga` (string) - The type of VGA card to emulate. If undefined, this will not be included
+  in the command-line, and the default qemu value for the emulated machine
+  will be picked.
+
 - `display` (string) - What QEMU -display option to use. Defaults to gtk, use none to not pass the
   -display option allowing QEMU to choose the default. This may be needed when
   running under macOS, and getting errors about sdl not being available.


### PR DESCRIPTION
The -vga option lets qemu choose which type of VGA card will be emulated for displaying the VM.

If not running in headless mode, this may be useful, as not all the displays support the same feature-set, and specific display types may be required for visualising the work that's being done.

Hence, this commit adds an extra option to the qemu configs to let us specify the VGA card type rather than mandating passing the value through the other qemu options.