### PR TITLE
builder: fix interpolation for build_steps

### DIFF
--- a/builder/qemu/config.go
+++ b/builder/qemu/config.go
@@ -632,6 +632,7 @@ func (c *Config) Prepare(raws ...interface{}) ([]string, error) {
 		InterpolateFilter: &interpolate.RenderFilter{
 			Exclude: []string{
 				"boot_command",
+				"boot_steps",
 				"qemuargs",
 			},
 		},


### PR DESCRIPTION
When the build_steps alternative for inputting boot commands was merged, we did not add an exception for interpolating its contents prior to the type_boot_command step.

This caused all its contents to be pre-interpolated, but since it relies on data that was not populated at interpolation-time, we ended-up with the templated content replaced by `<no value>`.

Adding the boot_steps to the exceptions fixes this problem.

Closes #109 
