### PR TITLE
CPU model option

### DIFF
--- a/builder/qemu/config.go
+++ b/builder/qemu/config.go
@@ -617,6 +617,21 @@ type Config struct {
 	// }
 	// ```
 	BootSteps [][]string `mapstructure:"boot_steps" required:"false"`
+	// The CPU model is what will be used by qemu for booting the virtual machine
+	// and determine which features of a specific model/family of processors
+	// is supported.
+	//
+	// Any string is supported here, and to see which models are supported
+	// by qemu for a specific architecture, refer to `qemu -cpu help`
+	//
+	// The default value here is that no cpu option will be passed through to qemu,
+	// therefore it will default to whichever CPU model is the default for the
+	// targetted system (on x86_64 for example, it will be qemu64)
+	//
+	// NOTE: RHEL9 removed support for `qemu64` in their distributed qemu package,
+	// forcing users of RHEL9 on x86_64 systems to define this. "host" is a
+	// reasonable value if using an hypervisor.
+	CPUModel string `mapstructure:"cpu_model" required:"false"`
 
 	// TODO(mitchellh): deprecate
 	RunOnce bool `mapstructure:"run_once"`

--- a/builder/qemu/config.hcl2spec.go
+++ b/builder/qemu/config.hcl2spec.go
@@ -144,6 +144,7 @@ type FlatConfig struct {
 	VTPMUseTPM1               *bool             `mapstructure:"use_tpm1" required:"false" cty:"use_tpm1" hcl:"use_tpm1"`
 	TPMType                   *string           `mapstructure:"tpm_device_type" required:"false" cty:"tpm_device_type" hcl:"tpm_device_type"`
 	BootSteps                 [][]string        `mapstructure:"boot_steps" required:"false" cty:"boot_steps" hcl:"boot_steps"`
+	CPUModel                  *string           `mapstructure:"cpu_model" required:"false" cty:"cpu_model" hcl:"cpu_model"`
 	RunOnce                   *bool             `mapstructure:"run_once" cty:"run_once" hcl:"run_once"`
 }
 
@@ -293,6 +294,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"use_tpm1":                     &hcldec.AttrSpec{Name: "use_tpm1", Type: cty.Bool, Required: false},
 		"tpm_device_type":              &hcldec.AttrSpec{Name: "tpm_device_type", Type: cty.String, Required: false},
 		"boot_steps":                   &hcldec.AttrSpec{Name: "boot_steps", Type: cty.List(cty.List(cty.String)), Required: false},
+		"cpu_model":                    &hcldec.AttrSpec{Name: "cpu_model", Type: cty.String, Required: false},
 		"run_once":                     &hcldec.AttrSpec{Name: "run_once", Type: cty.Bool, Required: false},
 	}
 	return s

--- a/builder/qemu/config_test.go
+++ b/builder/qemu/config_test.go
@@ -675,9 +675,9 @@ func TestBuilderPrepare_LoadQemuImgArgs(t *testing.T) {
 	var c Config
 	config := testConfig()
 	config["qemu_img_args"] = map[string][]string{
-		"convert": []string{"-o", "preallocation=full"},
-		"resize":  []string{"-foo", "bar"},
-		"create":  []string{"-baz", "bang"},
+		"convert": {"-o", "preallocation=full"},
+		"resize":  {"-foo", "bar"},
+		"create":  {"-baz", "bang"},
 	}
 	warns, err := c.Prepare(config)
 	if len(warns) > 0 {

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -147,6 +147,11 @@ func (s *stepRun) getDefaultArgs(config *Config, state multistep.StateBag) map[s
 	// Configure "-smp" processor hardware arguments
 	defaultArgs["-smp"] = config.QemuSMPConfig.getDefaultCmdLine()
 
+	// Configure "-cpu" cpu model argument
+	if config.CPUModel != "" {
+		defaultArgs["-cpu"] = config.CPUModel
+	}
+
 	// Configure "-fda" floppy disk attachment
 	if floppyPathRaw, ok := state.GetOk("floppy_path"); ok {
 		defaultArgs["-fda"] = floppyPathRaw.(string)

--- a/builder/qemu/step_run_test.go
+++ b/builder/qemu/step_run_test.go
@@ -436,6 +436,7 @@ func Test_OptionalConfigOptionsGetSet(t *testing.T) {
 		VMName:         "MyFancyName",
 		MachineType:    "pc",
 		Accelerator:    "hvf",
+		CPUModel:       "host",
 	}
 
 	state := runTestState(t, c)
@@ -452,6 +453,7 @@ func Test_OptionalConfigOptionsGetSet(t *testing.T) {
 		"-display", "gtk",
 		"-m", "0M",
 		"-boot", "once=d",
+		"-cpu", "host",
 		"-fda", "fake_floppy_path",
 		"-name", "MyFancyName",
 		"-netdev", "user,id=user.0,hostfwd=tcp::5000-:0",

--- a/docs-partials/builder/qemu/Config-not-required.mdx
+++ b/docs-partials/builder/qemu/Config-not-required.mdx
@@ -402,4 +402,19 @@
   }
   ```
 
+- `cpu_model` (string) - The CPU model is what will be used by qemu for booting the virtual machine
+  and determine which features of a specific model/family of processors
+  is supported.
+  
+  Any string is supported here, and to see which models are supported
+  by qemu for a specific architecture, refer to `qemu -cpu help`
+  
+  The default value here is that no cpu option will be passed through to qemu,
+  therefore it will default to whichever CPU model is the default for the
+  targetted system (on x86_64 for example, it will be qemu64)
+  
+  NOTE: RHEL9 removed support for `qemu64` in their distributed qemu package,
+  forcing users of RHEL9 on x86_64 systems to define this. "host" is a
+  reasonable value if using an hypervisor.
+
 <!-- End of code generated from the comments of the Config struct in builder/qemu/config.go; -->

--- a/docs-partials/builder/qemu/QemuEFIBootConfig-not-required.mdx
+++ b/docs-partials/builder/qemu/QemuEFIBootConfig-not-required.mdx
@@ -3,6 +3,9 @@
 - `efi_boot` (bool) - Boot in EFI mode instead of BIOS. This is required for more modern
   guest OS. If either or both of `efi_firmware_code` or
   `efi_firmware_vars` are defined, this will implicitely be set to `true`.
+  
+  NOTE: when using a Secure-Boot enabled firmware, the machine type has
+  to be q35, otherwise qemu will not boot.
 
 - `efi_firmware_code` (string) - Path to the CODE part of OVMF (or other compatible firmwares)
   The OVMF_CODE.fd file contains the bootstrap code for booting in EFI

--- a/example/efi_build/efi-debian.pkr.hcl
+++ b/example/efi_build/efi-debian.pkr.hcl
@@ -34,8 +34,8 @@ source "qemu" "debian_efi" {
 	]
 	http_directory = "http"
 	boot_wait     = "3s"
+	cpu_model      = "host"
 	qemuargs          = [
-		["-cpu", "host"],
 		["-vga","virtio"] # if vga is not virtio, output is garbled for some reason
 	]
 	vtpm              = true


### PR DESCRIPTION
As discussed in the RHEL9 panic issue linked to this PR, this PR is an attempt to make it easier for users of Packer/qemu on RHEL9+ hosts to set the CPU model for their builds.

Since `qemu64` (the default value) is not supported anymore on such hosts, we add this option to make it easier for those users to set a supported value. This also gives us a good opportunity to document the kind of workaround necessary to make a build work in such an environment.

When the value is not set, the option is not automatically added (we can maybe discuss this part, @nywilken, what do you think?).

Closes: #76 