### PR TITLE
Do not set boot device when doing UEFI based QEMU builds

### DIFF
--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -84,7 +84,9 @@ func (s *stepRun) getDefaultArgs(config *Config, state multistep.StateBag) map[s
 		message = "Starting VM, booting disk image"
 	}
 	s.ui.Say(message)
-	defaultArgs["-boot"] = bootDrive
+	if !config.QemuEFIBootConfig.EnableEFI {
+		defaultArgs["-boot"] = bootDrive
+	}
 
 	// configure "-qmp" arguments
 	if config.QMPEnable {

--- a/builder/qemu/step_run_test.go
+++ b/builder/qemu/step_run_test.go
@@ -142,6 +142,32 @@ func Test_DriveAndDeviceArgs(t *testing.T) {
 		},
 		{
 			&Config{
+				QemuEFIBootConfig: QemuEFIBootConfig{
+					EnableEFI: true,
+					OVMFCode:  "/path/to/fake_efi_code.fd",
+				},
+				OutputDir:     "path_to_output",
+				DiskCache:     "writeback",
+				DiskInterface: "virtio-scsi",
+				DiskImage:     true,
+				Format:        "qcow2",
+			},
+			map[string]interface{}{
+				efivarStateKey: "/path/to/fake_temporary_efi_vars.fd",
+			},
+			&stepRun{
+				DiskImage: true,
+				ui:        packersdk.TestUi(t),
+			},
+			[]string{
+				"-drive", "file=/path/to/fake_efi_code.fd,if=pflash,unit=0,format=raw,readonly=on",
+				"-drive", "file=/path/to/fake_temporary_efi_vars.fd,if=pflash,unit=1,format=raw",
+				"-drive", "file=path_to_output,if=virtio-scsi,cache=writeback,format=qcow2",
+			},
+			"Boot value (-boot) should not be set when using UEFI builds",
+		},
+		{
+			&Config{
 				DiskImage:     true,
 				DiskInterface: "virtio-scsi",
 


### PR DESCRIPTION
Describe the change you are making here!
The boot mode that packer defaults to (` "-boot", "foo"`) is ignored in UEFI mode. This is a harmless failure on x86_64 but when using aarch64, QEMU will reject this option and bail out with the following error:
```
2023/01/23 16:55:28 packer-1.8.5 plugin: Started Qemu. Pid: 3594063
2023/01/23 16:55:28 packer-1.8.5 plugin: Qemu stderr: qemu-system-aarch64: no function defined to set boot device list for this architecture
```

Added a test case for this, also verified working on RHEL9
