### PR TITLE
Build plugin for illumos.

### DIFF
--- a/.goreleaser.yml
+++ b/.goreleaser.yml
@@ -70,6 +70,7 @@ builds:
       - openbsd
       - freebsd
       - windows
+      - illumos
       - solaris
     goarch:
       - amd64
@@ -78,6 +79,10 @@ builds:
     ignore:
       - goos: windows
         goarch: arm
+      - goos: illumos
+        goarch: arm
+      - goos: illumos
+        goarch: '386'
       - goos: solaris
         goarch: arm
       - goos: solaris


### PR DESCRIPTION
This hopefully results in illumos binaries being made available, currently the experience is:

```shell
$ packer init -upgrade .
Failed getting the "github.com/hashicorp/qemu" plugin:
58 errors occurred:
        * ignoring invalid remote binary packer-plugin-qemu_v1.0.9_x5.0_linux_amd64.zip: wrong system, expected illumos_amd64 
[...]
        * could not install any compatible version of plugin "github.com/hashicorp/qemu"
```

Many thanks.