### PR TITLE
docs: add links to SMP and EFI configs

### DIFF
--- a/builder/qemu/config.go
+++ b/builder/qemu/config.go
@@ -178,11 +178,11 @@ type QemuEFIBootConfig struct {
 	// mode, and requires a separate VARS.fd file to be able to persist data
 	// between boot cycles.
 	//
-	// Default: /usr/share/OVMF/OVMF_CODE.fd
+	// Default: `/usr/share/OVMF/OVMF_CODE.fd`
 	OVMFCode string `mapstructure:"efi_firmware_code" required:"false"`
 	// Path to the VARS corresponding to the OVMF code file.
 	//
-	// Default: /usr/share/OVMF/OVMF_VARS.fd
+	// Default: `/usr/share/OVMF/OVMF_VARS.fd`
 	OVMFVars string `mapstructure:"efi_firmware_vars" required:"false"`
 }
 
@@ -252,7 +252,8 @@ type Config struct {
 	// If unset, QEMU will load its default firmware.
 	// Also see the QEMU documentation.
 	//
-	// NOTE: when booting in UEFI mode, please use the `efi_` options to
+	// NOTE: when booting in UEFI mode, please use the `efi_` (see
+	// [EFI Boot Configuration](#efi-boot-configuration)) options to
 	// setup the firmware.
 	Firmware string `mapstructure:"firmware" required:"false"`
 	// If a firmware file option was provided, this option can be
@@ -261,7 +262,8 @@ type Config struct {
 	// the -bios option, but if true, a pflash drive will be used
 	// instead.
 	//
-	// NOTE: when booting in UEFI mode, please use the `efi_` options to
+	// NOTE: when booting in UEFI mode, please use the `efi_` (see
+	// [EFI Boot Configuration](#efi-boot-configuration)) options to
 	// setup the firmware.
 	PFlash bool `mapstructure:"use_pflash" required:"false"`
 	// The interface to use for the disk. Allowed values include any of `ide`,

--- a/builder/qemu/config.go
+++ b/builder/qemu/config.go
@@ -68,12 +68,12 @@ type QemuImgArgs struct {
 // QemuSMPConfig sets the smp configuration option for the Qemu command-line
 //
 // The smp option sets the number of vCPUs to expose to the VM, the final
-// number of available vCPUs is sockets*cores*threads.
+// number of available vCPUs is `sockets * cores * threads`.
 type QemuSMPConfig struct {
 	// The number of virtual cpus to use when building the VM.
 	//
 	// If undefined, the value will either be `1`, or the product of
-	// `sockets * cpus * threads`
+	// `sockets * cores * threads`
 	//
 	// If this is defined in conjunction with any topology specifier (sockets,
 	// cores and/or threads), the smallest of the two will be used.

--- a/docs-partials/builder/qemu/Config-not-required.mdx
+++ b/docs-partials/builder/qemu/Config-not-required.mdx
@@ -36,7 +36,8 @@
   If unset, QEMU will load its default firmware.
   Also see the QEMU documentation.
   
-  NOTE: when booting in UEFI mode, please use the `efi_` options to
+  NOTE: when booting in UEFI mode, please use the `efi_` (see
+  [EFI Boot Configuration](#efi-boot-configuration)) options to
   setup the firmware.
 
 - `use_pflash` (bool) - If a firmware file option was provided, this option can be
@@ -45,7 +46,8 @@
   the -bios option, but if true, a pflash drive will be used
   instead.
   
-  NOTE: when booting in UEFI mode, please use the `efi_` options to
+  NOTE: when booting in UEFI mode, please use the `efi_` (see
+  [EFI Boot Configuration](#efi-boot-configuration)) options to
   setup the firmware.
 
 - `disk_interface` (string) - The interface to use for the disk. Allowed values include any of `ide`,

--- a/docs-partials/builder/qemu/QemuEFIBootConfig-not-required.mdx
+++ b/docs-partials/builder/qemu/QemuEFIBootConfig-not-required.mdx
@@ -12,10 +12,10 @@
   mode, and requires a separate VARS.fd file to be able to persist data
   between boot cycles.
   
-  Default: /usr/share/OVMF/OVMF_CODE.fd
+  Default: `/usr/share/OVMF/OVMF_CODE.fd`
 
 - `efi_firmware_vars` (string) - Path to the VARS corresponding to the OVMF code file.
   
-  Default: /usr/share/OVMF/OVMF_VARS.fd
+  Default: `/usr/share/OVMF/OVMF_VARS.fd`
 
 <!-- End of code generated from the comments of the QemuEFIBootConfig struct in builder/qemu/config.go; -->

--- a/docs-partials/builder/qemu/QemuSMPConfig-not-required.mdx
+++ b/docs-partials/builder/qemu/QemuSMPConfig-not-required.mdx
@@ -3,7 +3,7 @@
 - `cpus` (int) - The number of virtual cpus to use when building the VM.
   
   If undefined, the value will either be `1`, or the product of
-  `sockets * cpus * threads`
+  `sockets * cores * threads`
   
   If this is defined in conjunction with any topology specifier (sockets,
   cores and/or threads), the smallest of the two will be used.

--- a/docs-partials/builder/qemu/QemuSMPConfig.mdx
+++ b/docs-partials/builder/qemu/QemuSMPConfig.mdx
@@ -3,6 +3,6 @@
 QemuSMPConfig sets the smp configuration option for the Qemu command-line
 
 The smp option sets the number of vCPUs to expose to the VM, the final
-number of available vCPUs is sockets*cores*threads.
+number of available vCPUs is `sockets * cores * threads`.
 
 <!-- End of code generated from the comments of the QemuSMPConfig struct in builder/qemu/config.go; -->

--- a/docs/builders/qemu.mdx
+++ b/docs/builders/qemu.mdx
@@ -188,6 +188,22 @@ necessary for this build to succeed and can be found further down the page.
 
 @include 'packer-plugin-sdk/bootcommand/BootConfig-not-required.mdx'
 
+## EFI Boot Configuration
+
+@include 'builder/qemu/QemuEFIBootConfig.mdx'
+
+### Optional
+
+@include 'builder/qemu/QemuEFIBootConfig-not-required.mdx'
+
+## SMP Configuration
+
+@include 'builder/qemu/QemuSMPConfig.mdx'
+
+### Optional
+
+@include 'builder/qemu/QemuSMPConfig-not-required.mdx'
+
 ### Communicator Configuration
 
 #### Optional:


### PR DESCRIPTION
Sicne the current docs do not show the SMP or EFI configuration attributes on devdot, we add sections to the main builder page to show those configuration attributes.
