### PR TITLE
builder: add efi_drop_efivars option to builder

### DIFF
--- a/.web-docs/components/builder/qemu/README.md
+++ b/.web-docs/components/builder/qemu/README.md
@@ -1309,6 +1309,18 @@ do so are different from what BIOS (default) booting will require.
   
   Default: `/usr/share/OVMF/OVMF_VARS.fd`
 
+- `efi_drop_efivars` (bool) - Drop the efivars.fd file in the exported artifact.
+  
+  In addition to the disks created by the builder, we also expose the
+  `efivars.fd` file if the image was booted with UEFI enabled.
+  
+  However, if the output is consumed by a post-processor (like AWS,
+  GCP, etc.), this may not be supported by the code, and since the file
+  is not a disk image, this will error.
+  This option can then be used to remove the `efivars.fd` from the
+  artifact produced by the builder, so it only lists the disks produced
+  instead.
+
 <!-- End of code generated from the comments of the QemuEFIBootConfig struct in builder/qemu/config.go; -->
 
 

--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -189,6 +189,11 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 		if err != nil {
 			return err
 		}
+		// Don't keep efivars.fd if explicitely disabled.
+		if b.config.QemuEFIBootConfig.DropEFIVars && filepath.Base(path) == "efivars.fd" {
+			return nil
+		}
+
 		if !info.IsDir() {
 			files = append(files, path)
 		}

--- a/builder/qemu/config.go
+++ b/builder/qemu/config.go
@@ -187,6 +187,18 @@ type QemuEFIBootConfig struct {
 	//
 	// Default: `/usr/share/OVMF/OVMF_VARS.fd`
 	OVMFVars string `mapstructure:"efi_firmware_vars" required:"false"`
+	// Drop the efivars.fd file in the exported artifact.
+	//
+	// In addition to the disks created by the builder, we also expose the
+	// `efivars.fd` file if the image was booted with UEFI enabled.
+	//
+	// However, if the output is consumed by a post-processor (like AWS,
+	// GCP, etc.), this may not be supported by the code, and since the file
+	// is not a disk image, this will error.
+	// This option can then be used to remove the `efivars.fd` from the
+	// artifact produced by the builder, so it only lists the disks produced
+	// instead.
+	DropEFIVars bool `mapstructure:"efi_drop_efivars" required:"false"`
 }
 
 func (efiCfg *QemuEFIBootConfig) loadDefaults() {

--- a/builder/qemu/config.hcl2spec.go
+++ b/builder/qemu/config.hcl2spec.go
@@ -104,6 +104,7 @@ type FlatConfig struct {
 	EnableEFI                 *bool             `mapstructure:"efi_boot" required:"false" cty:"efi_boot" hcl:"efi_boot"`
 	OVMFCode                  *string           `mapstructure:"efi_firmware_code" required:"false" cty:"efi_firmware_code" hcl:"efi_firmware_code"`
 	OVMFVars                  *string           `mapstructure:"efi_firmware_vars" required:"false" cty:"efi_firmware_vars" hcl:"efi_firmware_vars"`
+	DropEFIVars               *bool             `mapstructure:"efi_drop_efivars" required:"false" cty:"efi_drop_efivars" hcl:"efi_drop_efivars"`
 	ISOSkipCache              *bool             `mapstructure:"iso_skip_cache" required:"false" cty:"iso_skip_cache" hcl:"iso_skip_cache"`
 	Accelerator               *string           `mapstructure:"accelerator" required:"false" cty:"accelerator" hcl:"accelerator"`
 	AdditionalDiskSize        []string          `mapstructure:"disk_additional_size" required:"false" cty:"disk_additional_size" hcl:"disk_additional_size"`
@@ -254,6 +255,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"efi_boot":                     &hcldec.AttrSpec{Name: "efi_boot", Type: cty.Bool, Required: false},
 		"efi_firmware_code":            &hcldec.AttrSpec{Name: "efi_firmware_code", Type: cty.String, Required: false},
 		"efi_firmware_vars":            &hcldec.AttrSpec{Name: "efi_firmware_vars", Type: cty.String, Required: false},
+		"efi_drop_efivars":             &hcldec.AttrSpec{Name: "efi_drop_efivars", Type: cty.Bool, Required: false},
 		"iso_skip_cache":               &hcldec.AttrSpec{Name: "iso_skip_cache", Type: cty.Bool, Required: false},
 		"accelerator":                  &hcldec.AttrSpec{Name: "accelerator", Type: cty.String, Required: false},
 		"disk_additional_size":         &hcldec.AttrSpec{Name: "disk_additional_size", Type: cty.List(cty.String), Required: false},

--- a/docs-partials/builder/qemu/QemuEFIBootConfig-not-required.mdx
+++ b/docs-partials/builder/qemu/QemuEFIBootConfig-not-required.mdx
@@ -18,4 +18,16 @@
   
   Default: `/usr/share/OVMF/OVMF_VARS.fd`
 
+- `efi_drop_efivars` (bool) - Drop the efivars.fd file in the exported artifact.
+  
+  In addition to the disks created by the builder, we also expose the
+  `efivars.fd` file if the image was booted with UEFI enabled.
+  
+  However, if the output is consumed by a post-processor (like AWS,
+  GCP, etc.), this may not be supported by the code, and since the file
+  is not a disk image, this will error.
+  This option can then be used to remove the `efivars.fd` from the
+  artifact produced by the builder, so it only lists the disks produced
+  instead.
+
 <!-- End of code generated from the comments of the QemuEFIBootConfig struct in builder/qemu/config.go; -->


### PR DESCRIPTION
By default when specifying EFI as boot method for the image, Packer produces two artifacts: the image itself, and the efivars.fd file that keeps the information about the EFI variables defined.

Since some post-processors use the output from a build to create images on a cloud provider, and they don't support having a efivars.fd file in the resulting archive/artifacts, we add a new option to leave it out of the artifacts from the builder, so they can work in conjunction with EFI images.

Closes #140 
