### PR TITLE
Add SSHKeygen step from SDK

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -113,6 +113,11 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			CommunicatorType: b.config.CommConfig.Comm.Type,
 			NetBridge:        b.config.NetBridge,
 		},
+		multistep.If(b.config.CommConfig.Comm.Type == "ssh",
+			&communicator.StepSSHKeyGen{
+				CommConf:            &b.config.CommConfig.Comm,
+				SSHTemporaryKeyPair: b.config.CommConfig.Comm.SSHTemporaryKeyPair,
+			}),
 		new(stepConfigureVNC),
 		&stepPrepareEfivars{
 			EFIEnabled: b.config.QemuEFIBootConfig.EnableEFI,

--- a/builder/qemu/step_type_boot_command.go
+++ b/builder/qemu/step_type_boot_command.go
@@ -20,9 +20,10 @@ import (
 const KeyLeftShift uint32 = 0xFFE1
 
 type bootCommandTemplateData struct {
-	HTTPIP   string
-	HTTPPort int
-	Name     string
+	HTTPIP       string
+	HTTPPort     int
+	Name         string
+	SSHPublicKey string
 }
 
 // This step "types" the boot command into the VM over VNC.
@@ -115,11 +116,13 @@ func typeBootCommands(ctx context.Context, state multistep.StateBag, bootSteps [
 	log.Printf("Connected to VNC desktop: %s", c.DesktopName)
 
 	hostIP := state.Get("http_ip").(string)
+	SSHPublicKey := string(config.CommConfig.Comm.SSHPublicKey)
 	configCtx := config.ctx
 	configCtx.Data = &bootCommandTemplateData{
 		hostIP,
 		httpPort,
 		config.VMName,
+		SSHPublicKey,
 	}
 
 	d := bootcommand.NewVNCDriver(c, config.VNCConfig.BootKeyInterval)

--- a/docs/builders/qemu.mdx
+++ b/docs/builders/qemu.mdx
@@ -167,6 +167,8 @@ necessary for this build to succeed and can be found further down the page.
 
 @include 'packer-plugin-sdk/communicator/SSH-Private-Key-File-not-required.mdx'
 
+@include 'packer-plugin-sdk/communicator/SSHTemporaryKeyPair-not-required.mdx'
+
 ### Optional WinRM fields:
 
 @include 'packer-plugin-sdk/communicator/WinRM-not-required.mdx'
@@ -204,6 +206,77 @@ necessary for this build to succeed and can be found further down the page.
 #### Optional:
 
 @include 'packer-plugin-sdk/communicator/Config-not-required.mdx'
+
+### SSH key pair automation
+
+The QEMU builder can inject the current SSH key pair's public key into
+the template using the `SSHPublicKey` template engine. This is the SSH public
+key as a line in OpenSSH authorized_keys format.
+
+When a private key is provided using `ssh_private_key_file`, the key's
+corresponding public key can be accessed using the above engine.
+
+@include 'packer-plugin-sdk/communicator/SSH-Private-Key-File-not-required.mdx'
+
+If `ssh_password` and `ssh_private_key_file` are not specified, Packer will
+automatically generate en ephemeral key pair. The key pair's public key can
+be accessed using the template engine.
+
+For example, the public key can be provided in the boot command as a URL
+encoded string by appending `| urlquery` to the variable:
+
+In JSON:
+
+```json
+"boot_command": [
+  "<up><wait><tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg PACKER_USER={{ user `username` }} PACKER_AUTHORIZED_KEY={{ .SSHPublicKey | urlquery }}<enter>"
+]
+```
+
+In HCL2:
+
+```hcl
+boot_command = [
+  "<up><wait><tab> text ks=http://{{ .HTTPIP }}:{{ .HTTPPort }}/ks.cfg PACKER_USER={{ user `username` }} PACKER_AUTHORIZED_KEY={{ .SSHPublicKey | urlquery }}<enter>"
+]
+```
+
+A kickstart could then leverage those fields from the kernel command line by
+decoding the URL-encoded public key:
+
+```shell
+%post
+
+# Newly created users need the file/folder framework for SSH key authentication.
+umask 0077
+mkdir /etc/skel/.ssh
+touch /etc/skel/.ssh/authorized_keys
+
+# Loop over the command line. Set interesting variables.
+for x in $(cat /proc/cmdline)
+do
+  case $x in
+    PACKER_USER=*)
+      PACKER_USER="${x#*=}"
+      ;;
+    PACKER_AUTHORIZED_KEY=*)
+      # URL decode $encoded into $PACKER_AUTHORIZED_KEY
+      encoded=$(echo "${x#*=}" | tr '+' ' ')
+      printf -v PACKER_AUTHORIZED_KEY '%b' "${encoded//%/\\x}"
+      ;;
+  esac
+done
+
+# Create/configure packer user, if any.
+if [ -n "$PACKER_USER" ]
+then
+  useradd $PACKER_USER
+  echo "%$PACKER_USER ALL=(ALL) NOPASSWD: ALL" >> /etc/sudoers.d/$PACKER_USER
+  [ -n "$PACKER_AUTHORIZED_KEY" ] && echo $PACKER_AUTHORIZED_KEY >> $(eval echo ~"$PACKER_USER")/.ssh/authorized_keys
+fi
+
+%end
+```
 
 ### Troubleshooting
 


### PR DESCRIPTION
This change adds the SSHKeyGen step from the SDK.

When the communicator configured is SSH, this step will generate a temporary ssh keypair when there is no ssh password and no ssh key configured.

Also included is the ability to use the SSHPublicKey variable inside the boot command.

This feature is present in the Virtualbox and VMware builders and I thought it would be good to have it here too.

