### PR TITLE
docs: update reference to community templates

### DIFF
--- a/.web-docs/components/builder/qemu/README.md
+++ b/.web-docs/components/builder/qemu/README.md
@@ -76,7 +76,7 @@ This is an example only, and will time out waiting for SSH because we have not
 provided a kickstart file. You must add a valid kickstart file to the
 "http_directory" and then provide the file in the "boot_command" in order for
 this build to run. We recommend you check out the
-[Community Templates](/community-tools#templates)
+[Community Templates](https://developer.hashicorp.com/packer/docs/community-tools#templates)
 for a practical usage example.
 
 Note that you will need to set `"headless": true` if you are running Packer

--- a/docs/builders/qemu.mdx
+++ b/docs/builders/qemu.mdx
@@ -87,7 +87,7 @@ This is an example only, and will time out waiting for SSH because we have not
 provided a kickstart file. You must add a valid kickstart file to the
 "http_directory" and then provide the file in the "boot_command" in order for
 this build to run. We recommend you check out the
-[Community Templates](/community-tools#templates)
+[Community Templates](https://developer.hashicorp.com/packer/docs/community-tools#templates)
 for a practical usage example.
 
 Note that you will need to set `"headless": true` if you are running Packer


### PR DESCRIPTION
The Community Templates link from the builder did not link to the community templates general documentation page, and instead was a broken link.

Closes #178 
