### PR TITLE
feat: enable predefined VNC passwords

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ dist/*
 packer-plugin-scaffolding
 example/output-ubuntu1804
 crash.log
+packer-plugin-qemu

--- a/.web-docs/components/builder/qemu/README.md
+++ b/.web-docs/components/builder/qemu/README.md
@@ -431,6 +431,8 @@ necessary for this build to succeed and can be found further down the page.
   binded to for VNC. By default packer will use 127.0.0.1 for this. If you
   wish to bind to all interfaces use 0.0.0.0.
 
+- `vnc_password` (string) - The password to set when VNCUsePassword == true.
+
 - `vnc_use_password` (bool) - Whether or not to set a password on the VNC server. This option
   automatically enables the QMP socket. See `qmp_socket_path`. Defaults to
   `false`.

--- a/builder/qemu/config.go
+++ b/builder/qemu/config.go
@@ -562,6 +562,8 @@ type Config struct {
 	// binded to for VNC. By default packer will use 127.0.0.1 for this. If you
 	// wish to bind to all interfaces use 0.0.0.0.
 	VNCBindAddress string `mapstructure:"vnc_bind_address" required:"false"`
+	// The password to set when VNCUsePassword == true.
+	VNCPassword string `mapstructure:"vnc_password" required:"false"`
 	// Whether or not to set a password on the VNC server. This option
 	// automatically enables the QMP socket. See `qmp_socket_path`. Defaults to
 	// `false`.

--- a/builder/qemu/config.hcl2spec.go
+++ b/builder/qemu/config.hcl2spec.go
@@ -136,8 +136,8 @@ type FlatConfig struct {
 	VGA                       *string           `mapstructure:"vga" required:"false" cty:"vga" hcl:"vga"`
 	Display                   *string           `mapstructure:"display" required:"false" cty:"display" hcl:"display"`
 	VNCBindAddress            *string           `mapstructure:"vnc_bind_address" required:"false" cty:"vnc_bind_address" hcl:"vnc_bind_address"`
+	VNCPassword               *string           `mapstructure:"vnc_password" required:"false" cty:"vnc_password" hcl:"vnc_password"`
 	VNCUsePassword            *bool             `mapstructure:"vnc_use_password" required:"false" cty:"vnc_use_password" hcl:"vnc_use_password"`
-	VNCPassword               *bool             `mapstructure:"vnc_password" required:"false" cty:"vnc_password" hcl:"vnc_password"`
 	VNCPortMin                *int              `mapstructure:"vnc_port_min" required:"false" cty:"vnc_port_min" hcl:"vnc_port_min"`
 	VNCPortMax                *int              `mapstructure:"vnc_port_max" cty:"vnc_port_max" hcl:"vnc_port_max"`
 	VMName                    *string           `mapstructure:"vm_name" required:"false" cty:"vm_name" hcl:"vm_name"`
@@ -288,6 +288,7 @@ func (*FlatConfig) HCL2Spec() map[string]hcldec.Spec {
 		"vga":                          &hcldec.AttrSpec{Name: "vga", Type: cty.String, Required: false},
 		"display":                      &hcldec.AttrSpec{Name: "display", Type: cty.String, Required: false},
 		"vnc_bind_address":             &hcldec.AttrSpec{Name: "vnc_bind_address", Type: cty.String, Required: false},
+		"vnc_password":                 &hcldec.AttrSpec{Name: "vnc_password", Type: cty.String, Required: false},
 		"vnc_use_password":             &hcldec.AttrSpec{Name: "vnc_use_password", Type: cty.Bool, Required: false},
 		"vnc_port_min":                 &hcldec.AttrSpec{Name: "vnc_port_min", Type: cty.Number, Required: false},
 		"vnc_port_max":                 &hcldec.AttrSpec{Name: "vnc_port_max", Type: cty.Number, Required: false},

--- a/builder/qemu/config.hcl2spec.go
+++ b/builder/qemu/config.hcl2spec.go
@@ -137,6 +137,7 @@ type FlatConfig struct {
 	Display                   *string           `mapstructure:"display" required:"false" cty:"display" hcl:"display"`
 	VNCBindAddress            *string           `mapstructure:"vnc_bind_address" required:"false" cty:"vnc_bind_address" hcl:"vnc_bind_address"`
 	VNCUsePassword            *bool             `mapstructure:"vnc_use_password" required:"false" cty:"vnc_use_password" hcl:"vnc_use_password"`
+	VNCPassword               *bool             `mapstructure:"vnc_password" required:"false" cty:"vnc_password" hcl:"vnc_password"`
 	VNCPortMin                *int              `mapstructure:"vnc_port_min" required:"false" cty:"vnc_port_min" hcl:"vnc_port_min"`
 	VNCPortMax                *int              `mapstructure:"vnc_port_max" cty:"vnc_port_max" hcl:"vnc_port_max"`
 	VMName                    *string           `mapstructure:"vm_name" required:"false" cty:"vm_name" hcl:"vm_name"`

--- a/docs-partials/builder/qemu/Config-not-required.mdx
+++ b/docs-partials/builder/qemu/Config-not-required.mdx
@@ -331,6 +331,9 @@
   binded to for VNC. By default packer will use 127.0.0.1 for this. If you
   wish to bind to all interfaces use 0.0.0.0.
 
+- `vnc_password` (bool) - The password to set for the VNC password when
+  `vnc_use_password` is true; automatically generated otherwise.
+
 - `vnc_use_password` (bool) - Whether or not to set a password on the VNC server. This option
   automatically enables the QMP socket. See `qmp_socket_path`. Defaults to
   `false`.

--- a/docs-partials/builder/qemu/Config-not-required.mdx
+++ b/docs-partials/builder/qemu/Config-not-required.mdx
@@ -331,8 +331,7 @@
   binded to for VNC. By default packer will use 127.0.0.1 for this. If you
   wish to bind to all interfaces use 0.0.0.0.
 
-- `vnc_password` (bool) - The password to set for the VNC password when
-  `vnc_use_password` is true; automatically generated otherwise.
+- `vnc_password` (string) - The password to set when VNCUsePassword == true.
 
 - `vnc_use_password` (bool) - Whether or not to set a password on the VNC server. This option
   automatically enables the QMP socket. See `qmp_socket_path`. Defaults to


### PR DESCRIPTION
This commit makes it possible to set a predefined password when
connecting to QEMU machines via VNC when `vnc_use_password` is `true`.

This way, having to set `PACKER_LOG=1` to retrieve the password is no
longer needed when troubleshooting builder VM bootstrap issues.
