### PR TITLE
changes for shutting down the VM for none communicator

### DIFF
--- a/builder/qemu/step_shutdown.go
+++ b/builder/qemu/step_shutdown.go
@@ -38,25 +38,7 @@ func (s *stepShutdown) Run(ctx context.Context, state multistep.StateBag) multis
 	driver := state.Get("driver").(Driver)
 	ui := state.Get("ui").(packersdk.Ui)
 
-	if s.Comm.Type == "none" {
-		cancelCh := make(chan struct{}, 1)
-		go func() {
-			defer close(cancelCh)
-			<-time.After(s.ShutdownTimeout)
-		}()
-		ui.Say("Waiting for shutdown...")
-		if ok := driver.WaitForShutdown(cancelCh); ok {
-			log.Println("VM shut down.")
-			return multistep.ActionContinue
-		} else {
-			err := fmt.Errorf("Failed to shutdown")
-			state.Put("error", err)
-			ui.Error(err.Error())
-			return multistep.ActionHalt
-		}
-	}
-
-	if s.ShutdownCommand != "" {
+	if s.ShutdownCommand != "" && s.Comm.Type != "none" {
 		comm := state.Get("communicator").(packersdk.Communicator)
 		ui.Say("Gracefully halting virtual machine...")
 		log.Printf("Executing shutdown command: %s", s.ShutdownCommand)

--- a/builder/qemu/step_shutdown_test.go
+++ b/builder/qemu/step_shutdown_test.go
@@ -42,7 +42,6 @@ func Test_Shutdown_Null_failure(t *testing.T) {
 	state := new(multistep.BasicStateBag)
 	state.Put("ui", packersdk.TestUi(t))
 	driverMock := new(DriverMock)
-	driverMock.WaitForShutdownState = false
 	state.Put("driver", driverMock)
 
 	step := &stepShutdown{
@@ -53,12 +52,14 @@ func Test_Shutdown_Null_failure(t *testing.T) {
 		},
 	}
 	action := step.Run(context.TODO(), state)
-	if action != multistep.ActionHalt {
-		t.Fatalf("Shouldn't have successfully shut down.")
+	if action != multistep.ActionContinue {
+		t.Fatalf("Should have successfully shut down.")
 	}
+
 	err := state.Get("error")
-	if err == nil {
-		t.Fatalf("Shutdown should have errored")
+	if err != nil {
+		err = err.(error)
+		t.Fatalf("Shutdown shouldn't have errored; err: %v", err)
 	}
 }
 


### PR DESCRIPTION
The shutdown step fix for QEMU in case of none communicator.



