### PR TITLE
Reordered steps so that temp ssh keys are available to the floppy and cd creators

### DIFF
--- a/builder/qemu/builder.go
+++ b/builder/qemu/builder.go
@@ -69,6 +69,11 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			vtpmType:   b.config.TPMType,
 			isTPM1:     b.config.VTPMUseTPM1,
 		},
+		multistep.If(b.config.CommConfig.Comm.Type == "ssh",
+			&communicator.StepSSHKeyGen{
+				CommConf:            &b.config.CommConfig.Comm,
+				SSHTemporaryKeyPair: b.config.CommConfig.Comm.SSHTemporaryKeyPair,
+			}),
 		&commonsteps.StepCreateFloppy{
 			Files:       b.config.FloppyConfig.FloppyFiles,
 			Content:     b.config.FloppyConfig.FloppyContent,
@@ -113,11 +118,6 @@ func (b *Builder) Run(ctx context.Context, ui packersdk.Ui, hook packersdk.Hook)
 			CommunicatorType: b.config.CommConfig.Comm.Type,
 			NetBridge:        b.config.NetBridge,
 		},
-		multistep.If(b.config.CommConfig.Comm.Type == "ssh",
-			&communicator.StepSSHKeyGen{
-				CommConf:            &b.config.CommConfig.Comm,
-				SSHTemporaryKeyPair: b.config.CommConfig.Comm.SSHTemporaryKeyPair,
-			}),
 		new(stepConfigureVNC),
 		&stepPrepareEfivars{
 			EFIEnabled: b.config.QemuEFIBootConfig.EnableEFI,


### PR DESCRIPTION
Reordered the build steps, so that temporary SSH Keys are created ahead of creating floppy and cd. This will allow for floppy/cd content to include the Public [or Private] keys.

Specifically, our use-case is placing the cloud-init user-data file in the CD with user-data.users.root.ssh-authorized-keys [pseudo name].

Existing tests for SSH keys and floppy and CD content, I understand, would cover.

