### PR TITLE
[Draft] Initial qcow2 firmware support

### DIFF
--- a/builder/qemu/isqcow2.go
+++ b/builder/qemu/isqcow2.go
@@ -1,0 +1,26 @@
+// Copyright (c) HashiCorp, Inc.
+// SPDX-License-Identifier: MPL-2.0
+
+package qemu
+
+import (
+	"os"
+)
+
+// Check for the magic bytes at the start of the file
+// which would indicate this is a qcow2 disk image
+func isQCOW2(path string) (bool, error) {
+	const qcow2Magic = "QFI\xfb"
+	file, err := os.Open(path)
+	if err != nil {
+		return false, err
+	}
+	defer file.Close()
+
+	magic := make([]byte, 4)
+	_, err = file.Read(magic)
+	if err != nil {
+		return false, err
+	}
+	return string(magic) == qcow2Magic, nil
+}

--- a/builder/qemu/step_prepare_efivars.go
+++ b/builder/qemu/step_prepare_efivars.go
@@ -31,7 +31,17 @@ func (s *stepPrepareEfivars) Run(ctx context.Context, state multistep.StateBag) 
 		return multistep.ActionContinue
 	}
 
-	dstPath := filepath.Join(s.OutputDir, "efivars.fd")
+	// Check whether EFI vars file is raw or qcow2 to determine
+	// which file extension to use when copying it locally
+	varsQCOW2, err := isQCOW2(s.SourcePath)
+	if err != nil {
+	}
+	varsFileExt := "fd"
+	if varsQCOW2 {
+		varsFileExt = "qcow2"
+	}
+
+	dstPath := fmt.Sprintf(filepath.Join(s.OutputDir, "efivars.%s"), varsFileExt)
 	outFile, err := os.OpenFile(dstPath, os.O_CREATE|os.O_WRONLY, 0660)
 	if err != nil {
 		errMsg := fmt.Sprintf("failed to create local efivars file at %s: %s", dstPath, err)

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -73,7 +73,7 @@ func (s *stepRun) Cleanup(state multistep.StateBag) {
 	}
 }
 
-func (s *stepRun) getDefaultArgs(config *Config, state multistep.StateBag) map[string]interface{} {
+func (s *stepRun) getDefaultArgs(config *Config, state multistep.StateBag) (map[string]interface{}, error) {
 
 	defaultArgs := make(map[string]interface{})
 
@@ -193,11 +193,14 @@ func (s *stepRun) getDefaultArgs(config *Config, state multistep.StateBag) map[s
 		defaultArgs["-vga"] = config.VGA
 	}
 
-	deviceArgs, driveArgs := s.getDeviceAndDriveArgs(config, state)
+	deviceArgs, driveArgs, err := s.getDeviceAndDriveArgs(config, state)
+	if err != nil {
+		return nil, err
+	}
 	defaultArgs["-device"] = deviceArgs
 	defaultArgs["-drive"] = driveArgs
 
-	return defaultArgs
+	return defaultArgs, err
 }
 
 func getVncConnectionMessage(headless bool, vnc string, vncPass string) string {
@@ -224,7 +227,7 @@ func getVncConnectionMessage(headless bool, vnc string, vncPass string) string {
 	return ""
 }
 
-func (s *stepRun) getDeviceAndDriveArgs(config *Config, state multistep.StateBag) ([]string, []string) {
+func (s *stepRun) getDeviceAndDriveArgs(config *Config, state multistep.StateBag) ([]string, []string, error) {
 	var deviceArgs []string
 	var driveArgs []string
 	availableScsiIndex := 0
@@ -305,11 +308,29 @@ func (s *stepRun) getDeviceAndDriveArgs(config *Config, state multistep.StateBag
 
 	// EFI
 	if config.QemuEFIBootConfig.EnableEFI {
-		// CODE binary is loaded readonly
-		driveArgs = append(driveArgs, fmt.Sprintf("file=%s,if=pflash,unit=0,format=raw,readonly=on", config.QemuEFIBootConfig.OVMFCode))
-		efivar := state.Get(efivarStateKey)
-		// the local copy of VARS is not
-		driveArgs = append(driveArgs, fmt.Sprintf("file=%s,if=pflash,unit=1,format=raw", efivar.(string)))
+		// Check format of CODE binary and load as read-only
+		codePath := config.QemuEFIBootConfig.OVMFCode
+		codeQCOW2, err := isQCOW2(codePath)
+		if err != nil {
+			return nil, nil, err
+		}
+		codeFormat := "raw"
+		if codeQCOW2 {
+			codeFormat = "qcow2"
+		}
+		driveArgs = append(driveArgs, fmt.Sprintf("file=%s,if=pflash,unit=0,format=%s,readonly=on", codePath, codeFormat))
+
+		// Check format of VARS file and load as writable
+		varsPath := state.Get(efivarStateKey)
+		varsQCOW2, err := isQCOW2(varsPath.(string))
+		if err != nil {
+			return nil, nil, err
+		}
+		varsFormat := "raw"
+		if varsQCOW2 {
+			varsFormat = "qcow2"
+		}
+   		driveArgs = append(driveArgs, fmt.Sprintf("file=%s,if=pflash,unit=1,format=%s", varsPath.(string), varsFormat))
 	}
 
 	// TPM
@@ -317,7 +338,7 @@ func (s *stepRun) getDeviceAndDriveArgs(config *Config, state multistep.StateBag
 		deviceArgs = append(deviceArgs, fmt.Sprintf("%s,tpmdev=tpm0", config.TPMType))
 	}
 
-	return deviceArgs, driveArgs
+	return deviceArgs, driveArgs, nil
 }
 
 func (s *stepRun) applyUserOverrides(defaultArgs map[string]interface{}, config *Config, state multistep.StateBag) ([]string, error) {
@@ -415,7 +436,10 @@ func (s *stepRun) applyUserOverrides(defaultArgs map[string]interface{}, config 
 }
 
 func (s *stepRun) getCommandArgs(config *Config, state multistep.StateBag) ([]string, error) {
-	defaultArgs := s.getDefaultArgs(config, state)
+	defaultArgs, err := s.getDefaultArgs(config, state)
+	if err != nil {
+		return nil, err
+	}
 
 	return s.applyUserOverrides(defaultArgs, config, state)
 }


### PR DESCRIPTION
### Description
This is a draft PR to add support for using EFI firmware in qcow2 format.

Merging this PR allows the plugin to keep up with the modern approach taken by distributions like Fedora which have retired raw versions of the 4M firmware images in their `edk2` package in favour of only shipping qcow2 versions.

This approach is unlikely to be reverted. I asked one of the maintainers about this and was told:

> The advantage of using qcow2 is that you save memory with sparse flash images.  That is important on arm, where the flash has a fixed size of 2x 64M and only a small fraction is actually used.  x64 has been switched over too for consistency.

So since it does not appear that this approach will go away, and other distros will likely follow suit, it makes sense for the plugin to update to handle this situation.

I have tested this and it works on a Fedora host using the `edk2` package and these EFI variables passed to a Packer QEMU source:
```hcl
efi_firmware_code         = "/usr/share/edk2/ovmf/OVMF_CODE_4M.secboot.qcow2"
efi_firmware_vars         = "/usr/share/edk2/ovmf/OVMF_VARS_4M.secboot.qcow2"
```

I think what I'm mostly missing here is updating tests to account for this new acceptable scenario of qcow2 firmware, and also updating documentation.

This is a _draft_ PR as I'm not super familiar with the codebase so feedback is very welcome on what might be needed to merge it!

### Resolved Issues
* This would resolve #225 
* This provides users on Fedora and possibly other distros with a mechanism to install Windows 11 with fully functional Secure Boot & TPM without using any bypasses.

### Rollback Plan
Unknown. Please advise.

This is a minimal change but I assume as it's quite a clean single PR it could easily be reverted if necessary.

### Changes to Security Controls

None.