### PR TITLE
feat(builder): expose ISOPath and CDPath to qemuargs template engine

### DIFF
--- a/.web-docs/components/builder/qemu/README.md
+++ b/.web-docs/components/builder/qemu/README.md
@@ -365,7 +365,8 @@ necessary for this build to succeed and can be found further down the page.
   
   This is a template engine and allows access to the following variables:
   `{{ .HTTPIP }}`, `{{ .HTTPPort }}`, `{{ .HTTPDir }}`,
-  `{{ .OutputDir }}`, `{{ .Name }}`, and `{{ .SSHHostPort }}`
+  `{{ .OutputDir }}`, `{{ .Name }}`, `{{ .SSHHostPort }}`,
+  `{{ .ISOPath }}`, and `{{ .CDPath }}`.
 
 - `qemu_img_args` (QemuImgArgs) - A map of custom arguments to pass to qemu-img commands, where the key
   is the subcommand, and the values are lists of strings for each flag.

--- a/builder/qemu/config.go
+++ b/builder/qemu/config.go
@@ -497,7 +497,8 @@ type Config struct {
 	//
 	// This is a template engine and allows access to the following variables:
 	// `{{ .HTTPIP }}`, `{{ .HTTPPort }}`, `{{ .HTTPDir }}`,
-	// `{{ .OutputDir }}`, `{{ .Name }}`, and `{{ .SSHHostPort }}`
+	// `{{ .OutputDir }}`, `{{ .Name }}`, `{{ .SSHHostPort }}`,
+	// `{{ .ISOPath }}`, and `{{ .CDPath }}`.
 	QemuArgs [][]string `mapstructure:"qemuargs" required:"false"`
 	// A map of custom arguments to pass to qemu-img commands, where the key
 	// is the subcommand, and the values are lists of strings for each flag.

--- a/builder/qemu/step_run.go
+++ b/builder/qemu/step_run.go
@@ -337,6 +337,9 @@ func (s *stepRun) applyUserOverrides(defaultArgs map[string]interface{}, config 
 		httpIp := state.Get("http_ip").(string)
 		httpPort := state.Get("http_port").(int)
 
+		isoPath, _ := state.Get("iso_path").(string)
+		cdPath, _ := state.Get("cd_path").(string)
+
 		type qemuArgsTemplateData struct {
 			HTTPIP      string
 			HTTPPort    int
@@ -345,6 +348,8 @@ func (s *stepRun) applyUserOverrides(defaultArgs map[string]interface{}, config 
 			OutputDir   string
 			Name        string
 			SSHHostPort int
+			ISOPath     string
+			CDPath      string
 		}
 
 		ictx := config.ctx
@@ -356,6 +361,8 @@ func (s *stepRun) applyUserOverrides(defaultArgs map[string]interface{}, config 
 			OutputDir:   config.OutputDir,
 			Name:        config.VMName,
 			SSHHostPort: commHostPort,
+			ISOPath:     isoPath,
+			CDPath:      cdPath,
 		}
 
 		// Interpolate each string in qemuargs

--- a/builder/qemu/step_run_test.go
+++ b/builder/qemu/step_run_test.go
@@ -119,6 +119,35 @@ func Test_UserOverrides(t *testing.T) {
 
 }
 
+func Test_ISOAndCDPathOverrides(t *testing.T) {
+	config := &Config{
+		VMName: "myvm",
+		QemuArgs: [][]string{
+			{"-isoflag", "file={{.ISOPath}},media=cdrom"},
+			{"-cdflag", "file={{.CDPath}},media=cdrom"},
+		},
+	}
+
+	state := runTestState(t, config)
+	state.Put("cd_path", "/path/to/cd_files.iso")
+
+	step := &stepRun{
+		atLeastVersion2: true,
+		ui:              packersdk.TestUi(t),
+	}
+	args, err := step.getCommandArgs(config, state)
+	if err != nil {
+		t.Fatalf("should not have an error getting args. Error: %s", err)
+	}
+
+	assert.True(t,
+		matchArgument(args, []string{"-isoflag", "file=/path/to/test.iso,media=cdrom"}),
+		fmt.Sprintf("{{.ISOPath}} should interpolate to the resolved ISO path. Received: %#v", args))
+	assert.True(t,
+		matchArgument(args, []string{"-cdflag", "file=/path/to/cd_files.iso,media=cdrom"}),
+		fmt.Sprintf("{{.CDPath}} should interpolate to the cd_files ISO path. Received: %#v", args))
+}
+
 func Test_DriveAndDeviceArgs(t *testing.T) {
 	type testCase struct {
 		Config     *Config

--- a/docs-partials/builder/qemu/Config-not-required.mdx
+++ b/docs-partials/builder/qemu/Config-not-required.mdx
@@ -265,7 +265,8 @@
   
   This is a template engine and allows access to the following variables:
   `{{ .HTTPIP }}`, `{{ .HTTPPort }}`, `{{ .HTTPDir }}`,
-  `{{ .OutputDir }}`, `{{ .Name }}`, and `{{ .SSHHostPort }}`
+  `{{ .OutputDir }}`, `{{ .Name }}`, `{{ .SSHHostPort }}`,
+  `{{ .ISOPath }}`, and `{{ .CDPath }}`.
 
 - `qemu_img_args` (QemuImgArgs) - A map of custom arguments to pass to qemu-img commands, where the key
   is the subcommand, and the values are lists of strings for each flag.


### PR DESCRIPTION
### Description

This patch exposes the `{{ .ISOPath }}` and `{{ .CDPath }}` parameters to the qemuargs template. This is relevant in cases, for example on windows, where the ISO files need to be attached as removable media (for unattended installs) and the IDE floppy integration is not available (AArch64).

