### PR TITLE
docs(qemu): clarify forceful halt when shutdown_command is empty

### DIFF
--- a/.web-docs/components/builder/qemu/README.md
+++ b/.web-docs/components/builder/qemu/README.md
@@ -891,6 +891,15 @@ boot time.
 <!-- End of code generated from the comments of the ShutdownConfig struct in shutdowncommand/config.go; -->
 
 
+~> **Note:** When a communicator (`ssh` or `winrm`) is used and
+`shutdown_command` is left empty, Packer forcefully halts the virtual machine by
+terminating the QEMU process once provisioning completes, even if a shutdown
+command was issued from within a provisioning script. A graceful, in-guest
+shutdown is only performed when `shutdown_command` is set, in which case Packer
+runs that command and waits up to `shutdown_timeout` for the machine to power
+off. When `communicator` is set to `none`, Packer instead waits up to
+`shutdown_timeout` for the guest to power off on its own.
+
 ## Communicator configuration
 
 ### Optional common fields:

--- a/docs/builders/qemu.mdx
+++ b/docs/builders/qemu.mdx
@@ -153,6 +153,15 @@ necessary for this build to succeed and can be found further down the page.
 
 @include 'packer-plugin-sdk/shutdowncommand/ShutdownConfig-not-required.mdx'
 
+~> **Note:** When a communicator (`ssh` or `winrm`) is used and
+`shutdown_command` is left empty, Packer forcefully halts the virtual machine by
+terminating the QEMU process once provisioning completes, even if a shutdown
+command was issued from within a provisioning script. A graceful, in-guest
+shutdown is only performed when `shutdown_command` is set, in which case Packer
+runs that command and waits up to `shutdown_timeout` for the machine to power
+off. When `communicator` is set to `none`, Packer instead waits up to
+`shutdown_timeout` for the guest to power off on its own.
+
 ## Communicator configuration
 
 ### Optional common fields:


### PR DESCRIPTION
### Description

Fixes #219.

The QEMU builder's [Shutdown configuration](https://developer.hashicorp.com/packer/integrations/hashicorp/qemu/latest/components/builder/qemu#shutdown-configuration) docs did not make clear what happens when `shutdown_command` is left empty. The reporter observed that a shutdown issued from within the last provisioning script does **not** result in a graceful power-off — the VM is still forcefully halted.

The source confirms this. In `builder/qemu/step_shutdown.go`, when a communicator (`ssh`/`winrm`) is used and `shutdown_command` is empty, the step takes the `else` branch and calls `driver.Stop()`:

```go
} else {
    ui.Say("Halting the virtual machine...")
    if err := driver.Stop(); err != nil {
```

and `QemuDriver.Stop()` (in `builder/qemu/driver.go`) forcefully kills the QEMU process:

```go
func (d *QemuDriver) Stop() error {
    ...
    if d.vmCmd != nil {
        if err := d.vmCmd.Process.Kill(); err != nil {
```

A graceful, in-guest shutdown is only performed when `shutdown_command` is set (Packer runs it and waits up to `shutdown_timeout`). When `communicator` is `none`, Packer instead waits up to `shutdown_timeout` for the guest to power off on its own.

### What this changes

Docs-only. Adds a QEMU-specific note to the Shutdown configuration section clarifying the actual behavior. Regenerated `.web-docs` via `make generate` so the compiled docs stay in sync (satisfies the `check-generate` CI job).

No code behavior is changed.