### PR TITLE
Use http_bind_address for HTTPIP when it is a specific address

### DIFF
--- a/builder/qemu/step_http_ip_discover.go
+++ b/builder/qemu/step_http_ip_discover.go
@@ -23,7 +23,12 @@ func (s *stepHTTPIPDiscover) Run(ctx context.Context, state multistep.StateBag) 
 
 	hostIP := ""
 
-	if config.NetBridge == "" {
+	// A specific http_bind_address is the address the HTTP server listens on,
+	// so guests should reach it there. Skip wildcards; those still need NAT or
+	// bridge discovery.
+	if config.HTTPAddress != "" && config.HTTPAddress != "0.0.0.0" && config.HTTPAddress != "::" {
+		hostIP = config.HTTPAddress
+	} else if config.NetBridge == "" {
 		hostIP = "10.0.2.2"
 	} else {
 		bridgeInterface, err := net.InterfaceByName(config.NetBridge)

--- a/builder/qemu/step_http_ip_discover_test.go
+++ b/builder/qemu/step_http_ip_discover_test.go
@@ -13,25 +13,54 @@ import (
 )
 
 func TestStepHTTPIPDiscover_Run(t *testing.T) {
-	state := new(multistep.BasicStateBag)
-	state.Put("ui", &packersdk.BasicUi{
-		Reader: new(bytes.Buffer),
-		Writer: new(bytes.Buffer),
-	})
-	config := &Config{}
-	state.Put("config", config)
-	step := new(stepHTTPIPDiscover)
-	hostIp := "10.0.2.2"
+	testcases := []struct {
+		name        string
+		httpAddress string
+		wantIP      string
+	}{
+		{
+			name:   "user mode NAT default",
+			wantIP: "10.0.2.2",
+		},
+		{
+			name:        "specific http_bind_address",
+			httpAddress: "1.2.3.4",
+			wantIP:      "1.2.3.4",
+		},
+		{
+			name:        "wildcard IPv4 bind still uses NAT address",
+			httpAddress: "0.0.0.0",
+			wantIP:      "10.0.2.2",
+		},
+		{
+			name:        "wildcard IPv6 bind still uses NAT address",
+			httpAddress: "::",
+			wantIP:      "10.0.2.2",
+		},
+	}
 
-	// Test the run
-	if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
-		t.Fatalf("bad action: %#v", action)
-	}
-	if _, ok := state.GetOk("error"); ok {
-		t.Fatal("should NOT have error")
-	}
-	httpIp := state.Get("http_ip").(string)
-	if httpIp != hostIp {
-		t.Fatalf("bad: Http ip is %s but was supposed to be %s", httpIp, hostIp)
+	for _, tc := range testcases {
+		t.Run(tc.name, func(t *testing.T) {
+			state := new(multistep.BasicStateBag)
+			state.Put("ui", &packersdk.BasicUi{
+				Reader: new(bytes.Buffer),
+				Writer: new(bytes.Buffer),
+			})
+			config := &Config{}
+			config.HTTPAddress = tc.httpAddress
+			state.Put("config", config)
+			step := new(stepHTTPIPDiscover)
+
+			if action := step.Run(context.Background(), state); action != multistep.ActionContinue {
+				t.Fatalf("bad action: %#v", action)
+			}
+			if _, ok := state.GetOk("error"); ok {
+				t.Fatal("should NOT have error")
+			}
+			httpIp := state.Get("http_ip").(string)
+			if httpIp != tc.wantIP {
+				t.Fatalf("bad: Http ip is %s but was supposed to be %s", httpIp, tc.wantIP)
+			}
+		})
 	}
 }


### PR DESCRIPTION
### Description
When http_bind_address is a specific IP, {{.HTTPIP}} now uses that address instead of always defaulting to 10.0.2.2. Wildcard binds still use the existing NAT or bridge discovery.

### Resolved Issues
Closes #253

### Rollback Plan
If a change needs to be reverted, we will roll out an update to the code within 7 days.

### Changes to Security Controls
No changes to security controls.